### PR TITLE
Update currency constants to align with 10 decimal places

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -305,8 +305,8 @@ fn testnet_genesis(
             ..Default::default()
         },
         balances: BalancesConfig {
-            // Configure endowed accounts with initial balance of 100 TNF
-            balances: endowed_accounts.iter().cloned().map(|k| (k, 100 * TNF)).collect(),
+            // Configure endowed accounts with initial balance of 100 TNF (BASE)
+            balances: endowed_accounts.iter().cloned().map(|k| (k, 100 * BASE)).collect(),
         },
         aura: AuraConfig { authorities: vec![] },
         grandpa: GrandpaConfig { ..Default::default() },
@@ -377,7 +377,7 @@ fn testnet_genesis(
                     endowed_accounts
                         .iter()
                         .cloned()
-                        .map(|k| (default_non_l2_token.unwrap(), k, 100 * TNF))
+                        .map(|k| (default_non_l2_token.unwrap(), k, 100 * BASE))
                         .collect()
                 } else {
                     vec![]

--- a/pallets/neo-swaps/src/consts.rs
+++ b/pallets/neo-swaps/src/consts.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Zeitgeist. If not, see <https://www.gnu.org/licenses/>.
 
-use prediction_market_primitives::constants::BASE;
+use common_primitives::constants::currency::BASE;
 
 /// Numerical limit for absolute value of exp arguments (not a fixed point number).
 pub(crate) const EXP_NUMERICAL_LIMIT: u128 = 10;

--- a/pallets/neo-swaps/src/lib.rs
+++ b/pallets/neo-swaps/src/lib.rs
@@ -46,6 +46,7 @@ mod pallet {
         weights::*,
     };
     use alloc::{collections::BTreeMap, vec, vec::Vec};
+    use common_primitives::constants::currency::{BASE, CENT_BASE};
     use core::marker::PhantomData;
     use frame_support::{
         dispatch::DispatchResultWithPostInfo,
@@ -63,7 +64,6 @@ mod pallet {
     use pallet_pm_market_commons::MarketCommonsPalletApi;
     use parity_scale_codec::{Decode, Encode};
     use prediction_market_primitives::{
-        constants::{BASE, CENT_BASE},
         hybrid_router_api_types::{AmmSoftFail, AmmTrade, ApiError},
         math::{
             checked_ops_res::{CheckedAddRes, CheckedSubRes},

--- a/pallets/neo-swaps/src/math.rs
+++ b/pallets/neo-swaps/src/math.rs
@@ -194,10 +194,8 @@ impl<T: Config> MathOps<T> for Math<T> {
 
 mod detail {
     use super::*;
-    use prediction_market_primitives::{
-        constants::DECIMALS,
-        math::fixed::{IntoFixedDecimal, IntoFixedFromDecimal},
-    };
+    use common_primitives::constants::currency::DECIMALS;
+    use prediction_market_primitives::math::fixed::{IntoFixedDecimal, IntoFixedFromDecimal};
 
     /// Calculate b * ln( e^(x/b) − 1 + e^(−r_i/b) ) + r_i − x.
     pub(super) fn calculate_swap_amount_out_for_buy(

--- a/pallets/prediction-markets/src/benchmarks.rs
+++ b/pallets/prediction-markets/src/benchmarks.rs
@@ -32,7 +32,7 @@ use crate::signed_calls::{
 #[cfg(test)]
 use crate::Pallet as PredictionMarket;
 use alloc::{vec, vec::Vec};
-use common_primitives::constants::{currency::TNF, MILLISECS_PER_BLOCK};
+use common_primitives::constants::{currency::BASE, MILLISECS_PER_BLOCK};
 use frame_benchmarking::{account, benchmarks, whitelisted_caller};
 use frame_support::{
     traits::{EnsureOrigin, Get, Hooks, UnfilteredDispatchable},
@@ -77,7 +77,7 @@ fn create_market_common_parameters<T: Config>(
         caller = actual_caller;
     }
 
-    T::AssetManager::deposit(Asset::Tnf, &caller, (100000u128 * TNF).saturated_into()).unwrap();
+    T::AssetManager::deposit(Asset::Tnf, &caller, (100000u128 * BASE).saturated_into()).unwrap();
     let oracle = caller.clone();
     let deadlines = Deadlines::<BlockNumberFor<T>> {
         grace_period: 1_u32.into(),

--- a/pallets/prediction-markets/src/lib.rs
+++ b/pallets/prediction-markets/src/lib.rs
@@ -36,7 +36,7 @@ pub use pallet::*;
 mod pallet {
     use crate::{alloc::borrow::ToOwned, signed_calls::*, weights::*};
     pub use alloc::{format, vec, vec::Vec};
-    use common_primitives::constants::MILLISECS_PER_BLOCK;
+    use common_primitives::constants::{currency::DECIMALS, MILLISECS_PER_BLOCK};
     use core::{cmp, marker::PhantomData};
     pub use frame_support::{
         dispatch::{DispatchResultWithPostInfo, GetDispatchInfo, Pays},
@@ -63,7 +63,6 @@ mod pallet {
     pub use pallet_pm_global_disputes::{types::InitialItem, GlobalDisputesPalletApi};
     pub use pallet_pm_market_commons::{types::MarketBuilder, MarketCommonsPalletApi};
     pub use prediction_market_primitives::{
-        constants::DECIMALS,
         traits::{
             CompleteSetOperationsApi, DeployPoolApi, DisputeApi, DisputeMaxWeightApi,
             DisputeResolutionApi, InspectEthAsset, MarketBuilderTrait,
@@ -3291,11 +3290,7 @@ mod pallet {
             );
 
             let valid_base_asset = match base_asset {
-                #[cfg(not(any(feature = "runtime-benchmarks", test)))]
-                Asset::Tnf => false, /* We can't support TNF because its a native token with 18 */
-                // decimal places
-                #[cfg(any(feature = "runtime-benchmarks", test))]
-                Asset::Tnf => true, // Allow it for tests to make things easier
+                Asset::Tnf => true,
                 Asset::ForeignAsset(fa) => {
                     if let Some(metadata) = T::AssetRegistry::metadata(&Asset::ForeignAsset(fa)) {
                         metadata.additional.allow_as_base_asset

--- a/primitives/common/src/constants.rs
+++ b/primitives/common/src/constants.rs
@@ -34,14 +34,15 @@ pub const SLOT_DURATION: u64 = MILLISECS_PER_BLOCK as u64;
 pub mod currency {
     use crate::types::Balance;
 
-    pub const PICO_TNF: Balance = 1_000_000;
-    pub const NANO_TNF: Balance = 1_000 * PICO_TNF;
-    pub const MICRO_TNF: Balance = 1_000 * NANO_TNF;
-    pub const MILLI_TNF: Balance = 1_000 * MICRO_TNF;
-    pub const TNF: Balance = 1_000 * MILLI_TNF;
+    // Definitions for currency used in Prediction market
+    pub const DECIMALS: u8 = 10;
+    pub const BASE: u128 = 10u128.pow(DECIMALS as u32);
+    pub const CENT_BASE: Balance = BASE / 100; // 100_000_000
+    pub const MILLI_BASE: Balance = CENT_BASE / 10; //  10_000_000
+    pub const MICRO_BASE: Balance = MILLI_BASE / 1000; // 10_000
 
     pub const fn deposit(items: u32, bytes: u32) -> Balance {
-        items as Balance * 10 * MILLI_TNF + (bytes as Balance) * 1 * MILLI_TNF
+        items as Balance * 50 * CENT_BASE + (bytes as Balance) * 75 * MICRO_BASE
     }
 
     #[cfg(test)]
@@ -51,11 +52,10 @@ pub mod currency {
         /// Checks that the native token amounts are correct.
         #[test]
         fn tnfd_amounts() {
-            assert_eq!(TNF, 1_000_000_000_000_000_000, "TNF should be 1_000_000_000_000_000_000");
-            assert_eq!(MILLI_TNF, 1_000_000_000_000_000, "mTNF should be 1_000_000_000_000_000");
-            assert_eq!(MICRO_TNF, 1_000_000_000_000, "μTNF should be 1_000_000_000_000");
-            assert_eq!(NANO_TNF, 1_000_000_000, "nTNF should be 1_000_000_000");
-            assert_eq!(PICO_TNF, 1_000_000, "pTNF should be 1_000_000");
+            assert_eq!(BASE, 10_000_000_000, "BASE (Full TNF) should be 10_000_000_000");
+            assert_eq!(CENT_BASE, 100_000_000, "cTNF should be 100_000_000");
+            assert_eq!(MILLI_BASE, 10_000_000, "mTNF should be 10_000_000");
+            assert_eq!(MICRO_BASE, 10_000, "μTNF should be 10_000");
         }
     }
 }

--- a/primitives/prediction-market/src/constants.rs
+++ b/primitives/prediction-market/src/constants.rs
@@ -29,16 +29,9 @@ pub mod mock;
 
 use common_primitives::{
     constants::{BLOCKS_PER_DAY, BLOCKS_PER_HOUR, BLOCKS_PER_YEAR},
-    types::{Balance, BlockNumber},
+    types::BlockNumber,
 };
 use frame_support::PalletId;
-
-// Definitions for currency used in Prediction market
-pub const DECIMALS: u8 = 10;
-pub const BASE: u128 = 10u128.pow(DECIMALS as u32);
-pub const CENT_BASE: Balance = BASE / 100; // 100_000_000
-pub const MILLI_BASE: Balance = CENT_BASE / 10; //  10_000_000
-pub const MICRO_BASE: Balance = MILLI_BASE / 1000; // 10_000
 
 // Authorized
 /// Pallet identifier, mainly used for named balance reserves.

--- a/primitives/prediction-market/src/constants/base_multiples.rs
+++ b/primitives/prediction-market/src/constants/base_multiples.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Zeitgeist. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::constants::BASE;
+use common_primitives::constants::currency::BASE;
 
 pub const _1: u128 = BASE;
 pub const _2: u128 = 2 * _1;

--- a/primitives/prediction-market/src/math/fixed.rs
+++ b/primitives/prediction-market/src/math/fixed.rs
@@ -23,12 +23,12 @@
 // <https://github.com/balancer-labs/balancer-core>.
 
 use super::checked_ops_res::{CheckedAddRes, CheckedDivRes, CheckedMulRes, CheckedSubRes};
-use crate::constants::BASE;
 use alloc::{
     borrow::ToOwned,
     format,
     string::{String, ToString},
 };
+use common_primitives::constants::currency::BASE;
 use core::{cmp::Ordering, convert::TryFrom, marker::PhantomData};
 use fixed::{traits::Fixed, ParseFixedError};
 use frame_support::ensure;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -201,7 +201,7 @@ impl WeightToFeePolynomial for WeightToFee {
     fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
         // We adjust the fee conversion so that the Extrinsic Base Weight corresponds to 150 micro
         // TNF fee.
-        let p = 150 * MICRO_TNF;
+        let p = 150 * MICRO_BASE;
         let q = Balance::from(ExtrinsicBaseWeight::get().ref_time());
         smallvec![WeightToFeeCoefficient {
             degree: 1,
@@ -418,7 +418,7 @@ impl pallet_timestamp::Config for Runtime {
 
 /// Existential deposit.
 pub const NATIVE_EXISTENTIAL_DEPOSIT: Balance = 0;
-pub const DEFAULT_EXISTENTIAL_DEPOSIT: Balance = 10 * PICO_TNF;
+pub const DEFAULT_EXISTENTIAL_DEPOSIT: Balance = 10 * MICRO_BASE;
 
 impl pallet_balances::Config for Runtime {
     type MaxLocks = ConstU32<50>;
@@ -445,9 +445,9 @@ parameter_types! {
     // in line with the weight fees.
     // An extrinsic usually has a payload with a few hundred bytes, and its weight
     // fee should be of a few milli TNF.
-    // In consequence TransactionByteFee should be set at a few MICRO_TNF.
+    // In consequence TransactionByteFee should be set at a few MICRO_BASE.
     // The actual value here was chosen to be a round number so that a Token Transfer be around 2mTNF, and a TNF transfer be around 1 mTNF.
-    pub const TransactionByteFee: Balance = 5 * MICRO_TNF;
+    pub const TransactionByteFee: Balance = 5 * MICRO_BASE;
     pub const OperationalFeeMultiplier: u8 = 5;
 }
 
@@ -689,8 +689,8 @@ impl pallet_preimage::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
     type Currency = Balances;
     type ManagerOrigin = EnsureRoot<AccountId>;
-    type BaseDeposit = ConstU128<{ 5 * TNF }>;
-    type ByteDeposit = ConstU128<{ 100 * MICRO_TNF }>;
+    type BaseDeposit = ConstU128<{ 5 * BASE }>;
+    type ByteDeposit = ConstU128<{ 100 * MICRO_BASE }>;
 }
 
 impl<C> frame_system::offchain::SendTransactionTypes<C> for Runtime
@@ -801,7 +801,7 @@ parameter_types! {
     /// This bond increases exponentially with the number of appeals.
     /// Slashed in case the final outcome does match the appealed outcome for which the `AppealBond`
     /// was deposited.
-    pub const AppealBond: Balance = 2000 * TNF;
+    pub const AppealBond: Balance = 2000 * BASE;
     /// The blocks per year required to calculate the yearly inflation for court incentivisation.
     pub const BlocksPerYear: BlockNumber = BLOCKS_PER_YEAR;
     /// Pallet identifier, mainly used for named balance reserves. DO NOT CHANGE.
@@ -827,7 +827,7 @@ parameter_types! {
     /// The maximum yearly inflation for court incentivisation.
     pub const MaxYearlyInflation: Perbill = Perbill::from_percent(10);
     /// The minimum stake a user needs to reserve to become a juror.
-    pub const MinJurorStake: Balance = 500 * TNF;
+    pub const MinJurorStake: Balance = 500 * BASE;
     /// The interval for requesting multiple court votes at once.
     pub const RequestInterval: BlockNumber = 7 * BLOCKS_PER_DAY;
 }
@@ -868,11 +868,11 @@ impl pallet_pm_market_commons::Config for Runtime {
 parameter_types! {
     /// (Slashable) Bond that is provided for creating an advised market that needs approval.
     /// Slashed in case the market is rejected.
-    pub const AdvisoryBond: Balance = 100 * TNF;
+    pub const AdvisoryBond: Balance = 100 * BASE;
     /// The percentage of the advisory bond that gets slashed when a market is rejected.
     pub const AdvisoryBondSlashPercentage: Percent = Percent::from_percent(0);
     /// (Slashable) Bond that is provided for disputing an early market close by the market creator.
-    pub const CloseEarlyDisputeBond: Balance = 2_000 * TNF;
+    pub const CloseEarlyDisputeBond: Balance = 2_000 * BASE;
     // Fat-finger protection for the advisory committe to reject
     // the early market schedule.
     pub const CloseEarlyProtectionTimeFramePeriod: Moment = CloseEarlyProtectionBlockPeriod::get() as u64 * MILLISECS_PER_BLOCK as u64;
@@ -880,11 +880,11 @@ parameter_types! {
     // the early market schedule.
     pub const CloseEarlyProtectionBlockPeriod: BlockNumber = 12 * BLOCKS_PER_HOUR;
     /// (Slashable) Bond that is provided for scheduling an early market close.
-    pub const CloseEarlyRequestBond: Balance = 2_000 * TNF;
+    pub const CloseEarlyRequestBond: Balance = 2_000 * BASE;
     /// (Slashable) Bond that is provided for disputing the outcome.
     /// Unreserved in case the dispute was justified otherwise slashed.
     /// This is when the resolved outcome is different to the default (reported) outcome.
-    pub const DisputeBond: Balance = 2_000 * TNF;
+    pub const DisputeBond: Balance = 2_000 * BASE;
     /// Maximum number of disputes.
     pub const MaxDisputes: u16 = 1;
     /// The dispute_duration is time where users can dispute the outcome.
@@ -914,11 +914,11 @@ parameter_types! {
     pub const MinOracleDuration: BlockNumber = MIN_ORACLE_DURATION;
     /// (Slashable) The orcale bond. Slashed in case the final outcome does not match the
     /// outcome the oracle reported.
-    pub const OracleBond: Balance = 100 * TNF;
+    pub const OracleBond: Balance = 100 * BASE;
     /// (Slashable) A bond for an outcome reporter, who is not the oracle.
     /// Slashed in case the final outcome does not match the outcome by the outsider.
     // If we remove the whitelist restriction for market creation, review this figure and ensure its > OracleBond
-    pub const OutsiderBond: Balance = 2000 * TNF;
+    pub const OutsiderBond: Balance = 2000 * BASE;
     /// Pallet identifier, mainly used for named balance reserves. DO NOT CHANGE.
     pub const PmPalletId: PalletId = PM_PALLET_ID;
     // Waiting time for market creator to close the market after an early close schedule.
@@ -927,7 +927,7 @@ parameter_types! {
     /// (Slashable) A bond for creation markets that do not require approval. Slashed in case
     /// the market is forcefully destroyed.
     // The low amount is assuming only whitelisted accounts can create a market
-    pub const ValidityBond: Balance = 100 * TNF;
+    pub const ValidityBond: Balance = 100 * BASE;
     // Orderbook parameters
     pub const OrderbookPalletId: PalletId = ORDERBOOK_PALLET_ID;
     // Hybrid Router parameters


### PR DESCRIPTION
## Proposed changes

This PR updates currency constants to align with 10 decimal places.
It also allows the native currency to be used as the base asset for prediction markets.


