### PR TITLE
Fix nonces not increasing and incorrect benchmarks and adds basic tests

### DIFF
--- a/pallets/hybrid-router/src/lib.rs
+++ b/pallets/hybrid-router/src/lib.rs
@@ -410,7 +410,7 @@ mod pallet {
                 strategy,
             )?;
 
-            MarketNonces::<T>::mutate(who, market_id, |nonce| *nonce + 1);
+            MarketNonces::<T>::mutate(who, market_id, |nonce| *nonce += 1);
             Ok(().into())
         }
 
@@ -463,7 +463,7 @@ mod pallet {
                 strategy,
             )?;
 
-            MarketNonces::<T>::mutate(who, market_id, |nonce| *nonce + 1);
+            MarketNonces::<T>::mutate(who, market_id, |nonce| *nonce += 1);
             Ok(().into())
         }
     }

--- a/pallets/prediction-markets/src/lib.rs
+++ b/pallets/prediction-markets/src/lib.rs
@@ -1599,7 +1599,7 @@ mod pallet {
 
             let weight = Self::do_redeem(who.clone(), market_id)?;
 
-            MarketNonces::<T>::mutate(who, market_id, |nonce| *nonce + 1);
+            MarketNonces::<T>::mutate(who, market_id, |nonce| *nonce += 1);
 
             Ok(Some(weight).into())
         }


### PR DESCRIPTION
This pull request includes several changes to the `pallets/hybrid-router` and `pallets/prediction-markets` modules to ensure that market nonces are correctly incremented. The most important changes involve modifying the way nonces are updated and adding verification steps in the benchmarks.

Changes to nonce updates:

* [`pallets/hybrid-router/src/lib.rs`](diffhunk://#diff-68dc16575d4509895aa2e5b05294b17d3ef8395be3176f27ad69d66a1f6f006bL413-R413): Updated `MarketNonces::<T>::mutate` to use the `+=` operator for incrementing nonces. [[1]](diffhunk://#diff-68dc16575d4509895aa2e5b05294b17d3ef8395be3176f27ad69d66a1f6f006bL413-R413) [[2]](diffhunk://#diff-68dc16575d4509895aa2e5b05294b17d3ef8395be3176f27ad69d66a1f6f006bL466-R466)
* [`pallets/prediction-markets/src/lib.rs`](diffhunk://#diff-3ef86506fe76b8e4c701a5b7dcf80a5454e76e7eecddd9b8f86e1d837f4e9604L1602-R1602): Updated `MarketNonces::<T>::mutate` to use the `+=` operator for incrementing nonces.

Verification steps in benchmarks:

* [`pallets/prediction-markets/src/benchmarks.rs`](diffhunk://#diff-afa154f37819d37303312ecbf696511c0e02dcf3879d736df2c5f3e8c27954bfL1665-R1674): Added verification steps to check that nonces are incremented correctly after dispatching calls in the `signed_report` and `signed_redeem_shares_categorical` benchmarks. [[1]](diffhunk://#diff-afa154f37819d37303312ecbf696511c0e02dcf3879d736df2c5f3e8c27954bfL1665-R1674) [[2]](diffhunk://#diff-afa154f37819d37303312ecbf696511c0e02dcf3879d736df2c5f3e8c27954bfL1679-R1713)