### PR TITLE
fix: Uses custodian class to allow migration to happen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "avn-key-subcommand"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "clap 4.5.4",
  "hex",
@@ -1241,7 +1241,7 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "common-primitives"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "arbitrary",
  "fixed",
@@ -5027,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "node-macros"
-version = "1.0.2"
+version = "1.0.3"
 
 [[package]]
 name = "node-primitives"
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-manager"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "common-primitives",
  "frame-benchmarking",
@@ -5677,7 +5677,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-authorized"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-court"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "arrayvec 0.7.4",
  "common-primitives",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-eth-asset-registry"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5743,7 +5743,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-global-disputes"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5766,7 +5766,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-hybrid-router"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "cfg-if 1.0.0",
  "common-primitives",
@@ -5805,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-market-commons"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-neo-swaps"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "cfg-if 1.0.0",
  "common-primitives",
@@ -5866,7 +5866,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-order-book"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-prediction-markets"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "cfg-if 1.0.0",
  "common-primitives",
@@ -5932,7 +5932,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-prediction-markets-runtime-api"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "parity-scale-codec 3.6.9",
  "prediction-market-primitives",
@@ -6608,7 +6608,7 @@ dependencies = [
 
 [[package]]
 name = "prediction-market-primitives"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "arbitrary",
  "common-primitives",
@@ -10424,7 +10424,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnf-node"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "avn-key-subcommand",
  "cfg-if 0.1.10",
@@ -10487,7 +10487,7 @@ dependencies = [
 
 [[package]]
 name = "tnf-node-runtime"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "common-primitives",
  "frame-benchmarking",
@@ -10561,7 +10561,7 @@ dependencies = [
 
 [[package]]
 name = "tnf-service"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Aventus systems team"]
 homepage = "https://www.truth-network.io/"
 edition = "2021"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -252,7 +252,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 4,
+    spec_version: 5,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

This commit compliments #24 and uses the ProcessedEventCustodian to couple the two pallets and migrate the events.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will be born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [ ] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [x] Patch release <!---i.ex v1.0.0 => v1.0.1-->

