### PR TITLE
SYS-4594 implement `deregister nodes`

### DIFF
--- a/pallets/node-manager/src/benchmarking.rs
+++ b/pallets/node-manager/src/benchmarking.rs
@@ -86,12 +86,15 @@ fn create_nodes_and_hearbeat<T: Config>(
     owner: T::AccountId,
     reward_period_index: RewardPeriodIndex,
     node_to_create: u32,
-) {
+) -> Vec<NodeId<T>> {
+    let mut registered_nodes = vec![];
     for i in 1..=node_to_create {
         let node: NodeId<T> = account("node", i, i);
         let _ = register_new_node::<T>(node.clone(), owner.clone());
         create_heartbeat::<T>(node.clone(), reward_period_index);
+        registered_nodes.push(node);
     }
+    registered_nodes
 }
 
 fn set_max_batch_size<T: Config>(batch_size: u32) {
@@ -273,7 +276,7 @@ benchmarks! {
         let owner: T::AccountId = account("owner", 0, 0);
         let author = create_author::<T>();
 
-        create_nodes_and_hearbeat::<T>(owner.clone(), reward_period_index, registered_nodes);
+        let _ = create_nodes_and_hearbeat::<T>(owner.clone(), reward_period_index, registered_nodes);
 
         // Move forward to the next reward period
         <frame_system::Pallet<T>>::set_block_number((reward_period.length + 1).into());
@@ -323,7 +326,7 @@ benchmarks! {
         let owner: T::AccountId = account("owner", 0, 0);
         let author = create_author::<T>();
 
-        create_nodes_and_hearbeat::<T>(owner.clone(), reward_period_index, n);
+        let _ = create_nodes_and_hearbeat::<T>(owner.clone(), reward_period_index, n);
 
         // Move forward to the next reward period
         <frame_system::Pallet<T>>::set_block_number((reward_period.length + 1).into());
@@ -369,6 +372,83 @@ benchmarks! {
         assert!(<OwnedNodes<T>>::contains_key(owner.clone(), node.clone()));
         assert!(<NodeRegistry<T>>::contains_key(node.clone()));
         assert_last_event::<T>(Event::NodeRegistered{owner, node}.into());
+    }
+
+    deregister_nodes {
+        let b in 1 .. MAX_NODES_TO_DEREGISTER;
+        let registrar: T::AccountId = account("registrar", 0, 0);
+        set_registrar::<T>(registrar.clone());
+
+        enable_rewards::<T>();
+        fund_reward_pot::<T>();
+
+        let reward_period = <RewardPeriod<T>>::get();
+        let reward_period_index = reward_period.current;
+        let owner: T::AccountId = account("owner", 0, 0);
+
+        let nodes_to_deregister = create_nodes_and_hearbeat::<T>(owner.clone(), reward_period_index, b);
+
+        // Show that the nodes are registered
+        assert!(<OwnedNodes<T>>::contains_key(owner.clone(), nodes_to_deregister[0].clone()));
+        assert!(<NodeRegistry<T>>::contains_key(nodes_to_deregister[0].clone()));
+
+    }: deregister_nodes(
+        RawOrigin::Signed(registrar.clone()),
+        owner.clone(),
+        BoundedVec::truncate_from(nodes_to_deregister.clone()), b as u32)
+    verify {
+        for node in &nodes_to_deregister {
+            assert!(!<OwnedNodes<T>>::contains_key(owner.clone(), node));
+            assert!(!<NodeRegistry<T>>::contains_key(node));
+        }
+        assert_last_event::<T>(Event::NodeDeregistered{
+            owner,
+            node: nodes_to_deregister[nodes_to_deregister.len() - 1].clone()}.into());
+    }
+
+    signed_deregister_nodes {
+        let b in 1 .. MAX_NODES_TO_DEREGISTER;
+        let registrar_key = crate::sr25519::app_sr25519::Public::generate_pair(None);
+        let registrar: T::AccountId =
+            T::AccountId::decode(&mut Encode::encode(&registrar_key).as_slice()).expect("valid account id");
+
+        set_registrar::<T>(registrar.clone());
+        enable_rewards::<T>();
+        fund_reward_pot::<T>();
+
+        let reward_period = <RewardPeriod<T>>::get();
+        let reward_period_index = reward_period.current;
+        let owner: T::AccountId = account("owner", 0, 0);
+
+        let nodes_to_deregister = create_nodes_and_hearbeat::<T>(owner.clone(), reward_period_index, b);
+
+        // Show that at least some of the nodes are registered
+        assert!(<OwnedNodes<T>>::contains_key(owner.clone(), nodes_to_deregister[0].clone()));
+        assert!(<NodeRegistry<T>>::contains_key(nodes_to_deregister[0].clone()));
+
+        let relayer: T::AccountId = account("relayer", 11, 11);
+        let now = frame_system::Pallet::<T>::block_number();
+
+        let bounded_nodes_to_deregister = BoundedVec::truncate_from(nodes_to_deregister.clone());
+        let signed_payload = encode_signed_deregister_node_params::<T>(
+            &relayer.clone(),
+            &owner,
+            &bounded_nodes_to_deregister,
+            &(nodes_to_deregister.len() as u32),
+            &now.clone(),
+        );
+
+        let signature = registrar_key.sign(&signed_payload).ok_or("Error signing proof")?;
+        let proof = get_proof::<T>(&relayer.clone(), &registrar, signature.into());
+    }: signed_deregister_nodes(RawOrigin::Signed(registrar.clone()), proof, owner.clone(), bounded_nodes_to_deregister, now, b as u32)
+    verify {
+        for node in &nodes_to_deregister {
+            assert!(!<OwnedNodes<T>>::contains_key(owner.clone(), node));
+            assert!(!<NodeRegistry<T>>::contains_key(node));
+        }
+        assert_last_event::<T>(Event::NodeDeregistered{
+            owner,
+            node: nodes_to_deregister[nodes_to_deregister.len() - 1].clone()}.into());
     }
 }
 

--- a/pallets/node-manager/src/default_weights.rs
+++ b/pallets/node-manager/src/default_weights.rs
@@ -51,6 +51,8 @@ pub trait WeightInfo {
 	fn offchain_pay_nodes(b: u32, ) -> Weight;
 	fn pay_nodes_constant_batch_size(n: u32, ) -> Weight;
 	fn signed_register_node() -> Weight;
+	fn deregister_nodes(b: u32, ) -> Weight;
+	fn signed_deregister_nodes(b: u32, ) -> Weight;
 }
 
 /// Weights for pallet_node_manager using the Substrate node and recommended hardware.
@@ -290,6 +292,52 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
+	/// Storage: `NodeManager::NodeRegistrar` (r:1 w:0)
+	/// Proof: `NodeManager::NodeRegistrar` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::OwnedNodes` (r:64 w:64)
+	/// Proof: `NodeManager::OwnedNodes` (`max_values`: None, `max_size`: Some(96), added: 2571, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::TotalRegisteredNodes` (r:1 w:1)
+	/// Proof: `NodeManager::TotalRegisteredNodes` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::NodeRegistry` (r:0 w:64)
+	/// Proof: `NodeManager::NodeRegistry` (`max_values`: None, `max_size`: Some(112), added: 2587, mode: `MaxEncodedLen`)
+	/// The range of component `b` is `[1, 64]`.
+	fn deregister_nodes(b: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `349 + b * (54 ±0)`
+		//  Estimated: `1517 + b * (2571 ±0)`
+		// Minimum execution time: 23_109_000 picoseconds.
+		Weight::from_parts(25_884_000, 1517)
+			// Standard Error: 79_418
+			.saturating_add(Weight::from_parts(13_605_065, 0).saturating_mul(b.into()))
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(b.into())))
+			.saturating_add(Weight::from_parts(0, 2571).saturating_mul(b.into()))
+	}
+	/// Storage: `NodeManager::NodeRegistrar` (r:1 w:0)
+	/// Proof: `NodeManager::NodeRegistrar` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::OwnedNodes` (r:64 w:64)
+	/// Proof: `NodeManager::OwnedNodes` (`max_values`: None, `max_size`: Some(96), added: 2571, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::TotalRegisteredNodes` (r:1 w:1)
+	/// Proof: `NodeManager::TotalRegisteredNodes` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::NodeRegistry` (r:0 w:64)
+	/// Proof: `NodeManager::NodeRegistry` (`max_values`: None, `max_size`: Some(112), added: 2587, mode: `MaxEncodedLen`)
+	/// The range of component `b` is `[1, 64]`.
+	fn signed_deregister_nodes(b: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `349 + b * (54 ±0)`
+		//  Estimated: `1517 + b * (2571 ±0)`
+		// Minimum execution time: 106_063_000 picoseconds.
+		Weight::from_parts(112_673_494, 1517)
+			// Standard Error: 156_464
+			.saturating_add(Weight::from_parts(14_673_199, 0).saturating_mul(b.into()))
+			.saturating_add(T::DbWeight::get().reads(2_u64))
+			.saturating_add(T::DbWeight::get().reads((1_u64).saturating_mul(b.into())))
+			.saturating_add(T::DbWeight::get().writes(1_u64))
+			.saturating_add(T::DbWeight::get().writes((2_u64).saturating_mul(b.into())))
+			.saturating_add(Weight::from_parts(0, 2571).saturating_mul(b.into()))
+	}
 }
 
 // For backwards compatibility and tests.
@@ -527,5 +575,51 @@ impl WeightInfo for () {
 		Weight::from_parts(112_274_000, 3577)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: `NodeManager::NodeRegistrar` (r:1 w:0)
+	/// Proof: `NodeManager::NodeRegistrar` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::OwnedNodes` (r:64 w:64)
+	/// Proof: `NodeManager::OwnedNodes` (`max_values`: None, `max_size`: Some(96), added: 2571, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::TotalRegisteredNodes` (r:1 w:1)
+	/// Proof: `NodeManager::TotalRegisteredNodes` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::NodeRegistry` (r:0 w:64)
+	/// Proof: `NodeManager::NodeRegistry` (`max_values`: None, `max_size`: Some(112), added: 2587, mode: `MaxEncodedLen`)
+	/// The range of component `b` is `[1, 64]`.
+	fn deregister_nodes(b: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `349 + b * (54 ±0)`
+		//  Estimated: `1517 + b * (2571 ±0)`
+		// Minimum execution time: 23_109_000 picoseconds.
+		Weight::from_parts(25_884_000, 1517)
+			// Standard Error: 79_418
+			.saturating_add(Weight::from_parts(13_605_065, 0).saturating_mul(b.into()))
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(b.into())))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(b.into())))
+			.saturating_add(Weight::from_parts(0, 2571).saturating_mul(b.into()))
+	}
+	/// Storage: `NodeManager::NodeRegistrar` (r:1 w:0)
+	/// Proof: `NodeManager::NodeRegistrar` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::OwnedNodes` (r:64 w:64)
+	/// Proof: `NodeManager::OwnedNodes` (`max_values`: None, `max_size`: Some(96), added: 2571, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::TotalRegisteredNodes` (r:1 w:1)
+	/// Proof: `NodeManager::TotalRegisteredNodes` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `NodeManager::NodeRegistry` (r:0 w:64)
+	/// Proof: `NodeManager::NodeRegistry` (`max_values`: None, `max_size`: Some(112), added: 2587, mode: `MaxEncodedLen`)
+	/// The range of component `b` is `[1, 64]`.
+	fn signed_deregister_nodes(b: u32, ) -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `349 + b * (54 ±0)`
+		//  Estimated: `1517 + b * (2571 ±0)`
+		// Minimum execution time: 106_063_000 picoseconds.
+		Weight::from_parts(112_673_494, 1517)
+			// Standard Error: 156_464
+			.saturating_add(Weight::from_parts(14_673_199, 0).saturating_mul(b.into()))
+			.saturating_add(RocksDbWeight::get().reads(2_u64))
+			.saturating_add(RocksDbWeight::get().reads((1_u64).saturating_mul(b.into())))
+			.saturating_add(RocksDbWeight::get().writes(1_u64))
+			.saturating_add(RocksDbWeight::get().writes((2_u64).saturating_mul(b.into())))
+			.saturating_add(Weight::from_parts(0, 2571).saturating_mul(b.into()))
 	}
 }

--- a/pallets/node-manager/src/lib.rs
+++ b/pallets/node-manager/src/lib.rs
@@ -48,6 +48,9 @@ mod test_admin;
 #[path = "tests/test_heartbeat.rs"]
 mod test_heartbeat;
 #[cfg(test)]
+#[path = "tests/test_node_deregistration.rs"]
+mod test_node_deregistration;
+#[cfg(test)]
 #[path = "tests/test_node_registration.rs"]
 mod test_node_registration;
 #[cfg(test)]
@@ -70,9 +73,9 @@ use sp_std::prelude::*;
 const PAYOUT_REWARD_CONTEXT: &'static [u8] = b"NodeManager_RewardPayout";
 const HEARTBEAT_CONTEXT: &'static [u8] = b"NodeManager_heartbeat";
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
-
 pub const SIGNED_REGISTER_NODE_CONTEXT: &[u8] = b"register_node";
 pub const SIGNED_DEREGISTER_NODE_CONTEXT: &[u8] = b"deregister_node";
+pub const MAX_NODES_TO_DEREGISTER: u32 = 64;
 
 // Error codes returned by validate unsigned methods
 /// Invalid signature for `paying` transaction
@@ -95,7 +98,7 @@ pub(crate) type RewardPeriodIndex = u64;
 /// A type alias for a unique identifier of a node
 pub(crate) type NodeId<T> = <T as frame_system::Config>::AccountId;
 /// The max number of nodes that can be deregistered in a single call
-pub type MaxNodesToDeregister = ConstU32<64>;
+pub type MaxNodesToDeregister = ConstU32<MAX_NODES_TO_DEREGISTER>;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/pallets/node-manager/src/lib.rs
+++ b/pallets/node-manager/src/lib.rs
@@ -700,7 +700,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(5)]
-        #[pallet::weight(0)]
+        #[pallet::weight(<T as Config>::WeightInfo::deregister_nodes(*number_of_nodes_to_deregister))]
         //#[pallet::weight(<T as Config>::WeightInfo::deregister_nodes())]
         pub fn deregister_nodes(
             origin: OriginFor<T>,
@@ -724,8 +724,7 @@ pub mod pallet {
         }
 
         #[pallet::call_index(6)]
-        #[pallet::weight(0)]
-        //#[pallet::weight(<T as Config>::WeightInfo::deregister_nodes())]
+        #[pallet::weight(<T as Config>::WeightInfo::signed_deregister_nodes(*number_of_nodes_to_deregister))]
         pub fn signed_deregister_nodes(
             origin: OriginFor<T>,
             proof: Proof<T::Signature, T::AccountId>,

--- a/pallets/node-manager/src/lib.rs
+++ b/pallets/node-manager/src/lib.rs
@@ -72,6 +72,7 @@ const HEARTBEAT_CONTEXT: &'static [u8] = b"NodeManager_heartbeat";
 pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 pub const SIGNED_REGISTER_NODE_CONTEXT: &[u8] = b"register_node";
+pub const SIGNED_DEREGISTER_NODE_CONTEXT: &[u8] = b"deregister_node";
 
 // Error codes returned by validate unsigned methods
 /// Invalid signature for `paying` transaction
@@ -93,6 +94,8 @@ pub(crate) type BalanceOf<T> =
 pub(crate) type RewardPeriodIndex = u64;
 /// A type alias for a unique identifier of a node
 pub(crate) type NodeId<T> = <T as frame_system::Config>::AccountId;
+/// The max number of nodes that can be deregistered in a single call
+pub type MaxNodesToDeregister = ConstU32<64>;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -291,6 +294,8 @@ pub mod pallet {
         RewardToggled { enabled: bool },
         /// A new minimum uptime threshold has been set
         MinUptimeThresholdSet { threshold: Perbill },
+        /// A node has been deregistered
+        NodeDeregistered { owner: T::AccountId, node: NodeId<T> },
     }
 
     // Pallet Errors
@@ -346,6 +351,10 @@ pub mod pallet {
         HeartbeatThresholdReached,
         /// The minimum uptime threshold is 0
         UptimeThresholdZero,
+        /// The number of nodes to deregister is not the same as the number of nodes provided
+        InvalidNumberOfNodes,
+        /// The specified node is not owned by the owner
+        NodeNotOwnedByOwner,
     }
 
     #[pallet::config]
@@ -686,6 +695,76 @@ pub mod pallet {
 
             Ok(())
         }
+
+        #[pallet::call_index(5)]
+        #[pallet::weight(0)]
+        //#[pallet::weight(<T as Config>::WeightInfo::deregister_nodes())]
+        pub fn deregister_nodes(
+            origin: OriginFor<T>,
+            owner: T::AccountId,
+            nodes_to_deregister: BoundedVec<NodeId<T>, MaxNodesToDeregister>,
+            // This is needed for benchmarks
+            number_of_nodes_to_deregister: u32,
+        ) -> DispatchResult {
+            let sender = ensure_signed(origin)?;
+            ensure!(
+                number_of_nodes_to_deregister == nodes_to_deregister.len() as u32,
+                Error::<T>::InvalidNumberOfNodes
+            );
+
+            let registrar = NodeRegistrar::<T>::get().ok_or(Error::<T>::RegistrarNotSet)?;
+            ensure!(registrar == sender, Error::<T>::OriginNotRegistrar);
+
+            Self::do_deregister_nodes(&owner, &nodes_to_deregister)?;
+
+            Ok(())
+        }
+
+        #[pallet::call_index(6)]
+        #[pallet::weight(0)]
+        //#[pallet::weight(<T as Config>::WeightInfo::deregister_nodes())]
+        pub fn signed_deregister_nodes(
+            origin: OriginFor<T>,
+            proof: Proof<T::Signature, T::AccountId>,
+            owner: T::AccountId,
+            nodes_to_deregister: BoundedVec<NodeId<T>, MaxNodesToDeregister>,
+            block_number: BlockNumberFor<T>,
+            // This is needed for benchmarks
+            number_of_nodes_to_deregister: u32,
+        ) -> DispatchResult {
+            let sender = ensure_signed(origin)?;
+            ensure!(sender == proof.signer, Error::<T>::SenderIsNotSigner);
+            ensure!(
+                number_of_nodes_to_deregister == nodes_to_deregister.len() as u32,
+                Error::<T>::InvalidNumberOfNodes
+            );
+
+            let registrar = NodeRegistrar::<T>::get().ok_or(Error::<T>::RegistrarNotSet)?;
+            ensure!(registrar == sender, Error::<T>::OriginNotRegistrar);
+            ensure!(
+                block_number.saturating_add(T::SignedTxLifetime::get().into()) >
+                    frame_system::Pallet::<T>::block_number(),
+                Error::<T>::SignedTransactionExpired
+            );
+
+            // Create and verify the signed payload
+            let signed_payload = encode_signed_deregister_node_params::<T>(
+                &proof.relayer,
+                &owner,
+                &nodes_to_deregister,
+                &number_of_nodes_to_deregister,
+                &block_number,
+            );
+
+            ensure!(
+                verify_signature::<T::Signature, T::AccountId>(&proof, &signed_payload).is_ok(),
+                Error::<T>::UnauthorizedSignedTransaction
+            );
+
+            Self::do_deregister_nodes(&owner, &nodes_to_deregister)?;
+
+            Ok(())
+        }
     }
 
     #[pallet::hooks]
@@ -818,6 +897,28 @@ pub mod pallet {
     }
 
     impl<T: Config> Pallet<T> {
+        fn do_deregister_nodes(
+            owner: &T::AccountId,
+            nodes: &BoundedVec<NodeId<T>, MaxNodesToDeregister>,
+        ) -> DispatchResult {
+            for node in nodes {
+                ensure!(
+                    <OwnedNodes<T>>::contains_key(owner, node),
+                    Error::<T>::NodeNotOwnedByOwner
+                );
+
+                <NodeRegistry<T>>::remove(node);
+                <OwnedNodes<T>>::remove(owner, node);
+                <TotalRegisteredNodes<T>>::mutate(|n| *n = n.saturating_sub(1));
+
+                Self::deposit_event(Event::NodeDeregistered {
+                    owner: owner.clone(),
+                    node: node.clone(),
+                });
+            }
+            Ok(())
+        }
+
         pub(crate) fn calculate_uptime_threshold(reward_period_length: u32) -> u32 {
             let heartbeat_period = HeartbeatPeriod::<T>::get();
             let threshold = MinUptimeThreshold::<T>::get().unwrap_or(Self::get_default_threshold());
@@ -889,6 +990,23 @@ pub mod pallet {
 
                     Some((proof, encoded_data))
                 },
+                Call::signed_deregister_nodes {
+                    ref proof,
+                    ref owner,
+                    ref nodes_to_deregister,
+                    ref block_number,
+                    ref number_of_nodes_to_deregister,
+                } => {
+                    let encoded_data = encode_signed_deregister_node_params::<T>(
+                        &proof.relayer,
+                        owner,
+                        nodes_to_deregister,
+                        number_of_nodes_to_deregister,
+                        block_number,
+                    );
+
+                    Some((proof, encoded_data))
+                },
                 _ => None,
             }
         }
@@ -923,4 +1041,22 @@ pub fn encode_signed_register_node_params<T: Config>(
     block_number: &BlockNumberFor<T>,
 ) -> Vec<u8> {
     (SIGNED_REGISTER_NODE_CONTEXT, relayer.clone(), node, owner, signing_key, block_number).encode()
+}
+
+pub fn encode_signed_deregister_node_params<T: Config>(
+    relayer: &T::AccountId,
+    owner: &T::AccountId,
+    nodes_to_deregister: &BoundedVec<NodeId<T>, MaxNodesToDeregister>,
+    number_of_nodes_to_deregister: &u32,
+    block_number: &BlockNumberFor<T>,
+) -> Vec<u8> {
+    (
+        SIGNED_DEREGISTER_NODE_CONTEXT,
+        relayer.clone(),
+        owner,
+        nodes_to_deregister,
+        number_of_nodes_to_deregister,
+        block_number,
+    )
+        .encode()
 }

--- a/pallets/node-manager/src/migration.rs
+++ b/pallets/node-manager/src/migration.rs
@@ -30,7 +30,6 @@ mod v1 {
 
 mod v2 {
     use super::*;
-    use frame_support::storage_alias;
 
     #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, MaxEncodedLen)]
     pub struct OldRewardPotInfo<T: crate::Config> {

--- a/pallets/node-manager/src/reward.rs
+++ b/pallets/node-manager/src/reward.rs
@@ -46,7 +46,7 @@ impl<T: Config> Pallet<T> {
                     reward_period: *period,
                     node: node.clone(),
                     amount,
-                    error: Error::<T>::NodeOwnerNotFound.into(),
+                    error: Error::<T>::NodeNotRegistered.into(),
                 });
                 // We skip paying rewards for this node and continue without erroring
                 return Ok(());

--- a/pallets/node-manager/src/reward.rs
+++ b/pallets/node-manager/src/reward.rs
@@ -38,7 +38,7 @@ impl<T: Config> Pallet<T> {
         let node_owner = match <NodeRegistry<T>>::get(&node) {
             Some(info) => info.owner,
             None => {
-                log::error!("💔 Error paying reward. Node not found in registry. Reward period: {:?}, Node {:?}, Amount: {:?}",
+                log::warn!("⚠️ Error paying reward. Node not found in registry. Reward period: {:?}, Node {:?}, Amount: {:?}",
                   period, node, amount
                 );
 

--- a/pallets/node-manager/src/tests/test_node_deregistration.rs
+++ b/pallets/node-manager/src/tests/test_node_deregistration.rs
@@ -2,9 +2,8 @@
 
 #![cfg(test)]
 
-use crate::{mock::*, offchain::OCW_ID, *};
+use crate::{mock::*, *};
 use frame_support::{assert_noop, assert_ok};
-use frame_system::RawOrigin;
 use prediction_market_primitives::{test_helper::TestAccount, types::SignatureTest};
 use sp_avn_common::Proof;
 use sp_core::Pair;

--- a/pallets/node-manager/src/tests/test_node_deregistration.rs
+++ b/pallets/node-manager/src/tests/test_node_deregistration.rs
@@ -1,0 +1,489 @@
+//Copyright 2025 Truth Network.
+
+#![cfg(test)]
+
+use crate::{mock::*, offchain::OCW_ID, *};
+use frame_support::{assert_noop, assert_ok};
+use frame_system::RawOrigin;
+use prediction_market_primitives::{test_helper::TestAccount, types::SignatureTest};
+use sp_avn_common::Proof;
+use sp_core::Pair;
+
+struct Context {
+    registrar_key_pair: TestAccount,
+    registrar: AccountId,
+    owner: AccountId,
+    relayer: AccountId,
+    registered_nodes: Vec<NodeId<TestRuntime>>,
+}
+
+impl Context {
+    fn new(num_of_nodes: u8) -> Self {
+        let registrar_key_pair = TestAccount::new([1u8; 32]);
+        let registrar = registrar_key_pair.account_id();
+        let owner = TestAccount::new([209u8; 32]).account_id();
+        let relayer = TestAccount::new([109u8; 32]).account_id();
+        let reward_amount: BalanceOf<TestRuntime> = <RewardAmount<TestRuntime>>::get();
+
+        Balances::make_free_balance_be(
+            &NodeManager::compute_reward_account_id(),
+            reward_amount * 2u128,
+        );
+        <NodeRegistrar<TestRuntime>>::set(Some(registrar.clone()));
+        let registered_nodes = register_nodes(registrar, owner, num_of_nodes);
+
+        Context { registrar_key_pair, registrar, owner, registered_nodes, relayer }
+    }
+}
+
+fn register_nodes(
+    registrar: AccountId,
+    owner: AccountId,
+    num_of_nodes: u8,
+) -> Vec<NodeId<TestRuntime>> {
+    let mut registered_nodes = vec![];
+    let reward_period = <RewardPeriod<TestRuntime>>::get().current;
+
+    for i in 0..num_of_nodes {
+        registered_nodes.push(register_node_and_send_heartbeat(
+            registrar,
+            owner.clone(),
+            reward_period,
+            i,
+        ));
+    }
+
+    let this_node = TestAccount::new([0 as u8; 32]).account_id();
+    let this_node_signing_key = 0;
+
+    set_ocw_node_id(this_node);
+    UintAuthorityId::set_all_keys(vec![UintAuthorityId(this_node_signing_key)]);
+
+    return registered_nodes;
+}
+
+fn register_node_and_send_heartbeat(
+    registrar: AccountId,
+    owner: AccountId,
+    reward_period: RewardPeriodIndex,
+    id: u8,
+) -> AccountId {
+    let node_id = TestAccount::new([id as u8; 32]).account_id();
+    let signing_key_id = id + 1;
+
+    assert_ok!(NodeManager::register_node(
+        RuntimeOrigin::signed(registrar),
+        node_id,
+        owner,
+        UintAuthorityId(signing_key_id as u64),
+    ));
+
+    incr_heartbeats(reward_period, vec![node_id], 1);
+    node_id
+}
+
+fn incr_heartbeats(reward_period: RewardPeriodIndex, nodes: Vec<NodeId<TestRuntime>>, uptime: u64) {
+    for node in nodes {
+        <NodeUptime<TestRuntime>>::mutate(&reward_period, &node, |maybe_info| {
+            if let Some(info) = maybe_info.as_mut() {
+                info.count = info.count.saturating_add(uptime);
+                info.last_reported = System::block_number();
+            } else {
+                *maybe_info = Some(UptimeInfo { count: 1, last_reported: System::block_number() });
+            }
+        });
+
+        <TotalUptime<TestRuntime>>::mutate(&reward_period, |total| {
+            *total = total.saturating_add(uptime);
+        });
+    }
+}
+
+fn pop_tx_from_mempool(pool_state: Arc<RwLock<PoolState>>) -> Extrinsic {
+    let tx = pool_state.write().transactions.pop().unwrap();
+    Extrinsic::decode(&mut &*tx).unwrap()
+}
+
+fn set_ocw_node_id(node_id: AccountId) {
+    let storage = StorageValueRef::persistent(REGISTERED_NODE_KEY);
+    storage
+        .mutate(|r: Result<Option<AccountId>, StorageRetrievalError>| match r {
+            Ok(Some(_)) => Ok(node_id),
+            Ok(None) => Ok(node_id),
+            _ => Err(()),
+        })
+        .unwrap();
+}
+
+fn create_signed_deregister_proof(
+    registrar_key_pair: &TestAccount,
+    relayer: &AccountId,
+    owner: &AccountId,
+    nodes_to_deregister: &BoundedVec<NodeId<TestRuntime>, MaxNodesToDeregister>,
+    number_of_nodes_to_deregister: &u32,
+    block_number: &BlockNumberFor<TestRuntime>,
+) -> Proof<SignatureTest, AccountId> {
+    let encoded_payload = encode_signed_deregister_node_params::<TestRuntime>(
+        relayer,
+        owner,
+        nodes_to_deregister,
+        number_of_nodes_to_deregister,
+        &block_number,
+    );
+
+    let signature = SignatureTest::from(registrar_key_pair.key_pair().sign(&encoded_payload));
+    let proof = Proof {
+        signer: registrar_key_pair.key_pair().public(),
+        relayer: relayer.clone(),
+        signature,
+    };
+
+    proof
+}
+
+#[test]
+fn deregistration_succeeds() {
+    let (mut ext, _, _) = ExtBuilder::build_default()
+        .with_genesis_config()
+        .for_offchain_worker()
+        .as_externality_with_state();
+    ext.execute_with(|| {
+        let node_count = <MaxBatchSize<TestRuntime>>::get();
+        let context = Context::new(node_count as u8);
+        let num_nodes_to_deregister = context.registered_nodes.len();
+
+        // Show that nodes are registered before deregistration
+        for node in &context.registered_nodes {
+            assert!(<OwnedNodes<TestRuntime>>::contains_key(context.owner.clone(), node));
+            assert!(<NodeRegistry<TestRuntime>>::contains_key(node));
+        }
+
+        assert_ok!(NodeManager::deregister_nodes(
+            RuntimeOrigin::signed(context.registrar),
+            context.owner,
+            BoundedVec::truncate_from(context.registered_nodes.clone()),
+            num_nodes_to_deregister as u32,
+        ));
+
+        for node in &context.registered_nodes {
+            assert!(!<OwnedNodes<TestRuntime>>::contains_key(context.owner.clone(), node));
+            assert!(!<NodeRegistry<TestRuntime>>::contains_key(node));
+        }
+        System::assert_last_event(
+            Event::NodeDeregistered {
+                owner: context.owner,
+                node: context.registered_nodes[num_nodes_to_deregister - 1].clone(),
+            }
+            .into(),
+        );
+    });
+}
+
+#[test]
+fn signed_deregistration_succeeds() {
+    let (mut ext, _, _) = ExtBuilder::build_default()
+        .with_genesis_config()
+        .for_offchain_worker()
+        .as_externality_with_state();
+    ext.execute_with(|| {
+        let node_count = <MaxBatchSize<TestRuntime>>::get();
+        let context = Context::new(node_count as u8);
+        let num_nodes_to_deregister = context.registered_nodes.len();
+        let block_number = System::block_number();
+
+        // Show that nodes are registered before deregistration
+        for node in &context.registered_nodes {
+            assert!(<OwnedNodes<TestRuntime>>::contains_key(context.owner.clone(), node));
+            assert!(<NodeRegistry<TestRuntime>>::contains_key(node));
+        }
+
+        let proof = create_signed_deregister_proof(
+            &context.registrar_key_pair,
+            &context.relayer,
+            &context.owner,
+            &(BoundedVec::truncate_from(context.registered_nodes.clone())),
+            &(num_nodes_to_deregister as u32),
+            &block_number,
+        );
+
+        assert_ok!(NodeManager::signed_deregister_nodes(
+            RuntimeOrigin::signed(context.registrar),
+            proof,
+            context.owner,
+            BoundedVec::truncate_from(context.registered_nodes.clone()),
+            block_number,
+            num_nodes_to_deregister as u32,
+        ));
+
+        for node in &context.registered_nodes {
+            assert!(!<OwnedNodes<TestRuntime>>::contains_key(context.owner.clone(), node));
+            assert!(!<NodeRegistry<TestRuntime>>::contains_key(node));
+        }
+        System::assert_last_event(
+            Event::NodeDeregistered {
+                owner: context.owner,
+                node: context.registered_nodes[num_nodes_to_deregister - 1].clone(),
+            }
+            .into(),
+        );
+    });
+}
+
+#[test]
+fn payment_works_all_nodes_deregistered() {
+    let (mut ext, pool_state, offchain_state) = ExtBuilder::build_default()
+        .with_genesis_config()
+        .with_authors()
+        .for_offchain_worker()
+        .as_externality_with_state();
+    ext.execute_with(|| {
+        let node_count = <MaxBatchSize<TestRuntime>>::get();
+        let context = Context::new(node_count as u8);
+        let num_nodes_to_deregister = context.registered_nodes.len();
+
+        assert_ok!(NodeManager::deregister_nodes(
+            RuntimeOrigin::signed(context.registrar),
+            context.owner,
+            BoundedVec::truncate_from(context.registered_nodes.clone()),
+            num_nodes_to_deregister as u32,
+        ));
+
+        for node in &context.registered_nodes {
+            assert!(!<OwnedNodes<TestRuntime>>::contains_key(context.owner.clone(), node));
+            assert!(!<NodeRegistry<TestRuntime>>::contains_key(node));
+        }
+
+        let reward_period = <RewardPeriod<TestRuntime>>::get();
+        let reward_amount = <RewardAmount<TestRuntime>>::get();
+        let reward_period_length = reward_period.length as u64;
+        let reward_period_to_pay = reward_period.current;
+
+        let initial_pot_balance = Balances::free_balance(&NodeManager::compute_reward_account_id());
+        let initial_owner_balance = Balances::free_balance(&context.owner);
+
+        // make sure the pot has the expected amount
+        assert_eq!(initial_pot_balance, reward_amount * 2u128);
+
+        // Complete a reward period
+        roll_forward((reward_period_length - System::block_number()) + 1);
+
+        assert_eq!(
+            <RewardPot<TestRuntime>>::get(reward_period_to_pay).unwrap().total_reward,
+            reward_amount
+        );
+        // mock finalised block response
+        mock_get_finalised_block(
+            &mut offchain_state.write(),
+            &Some(hex::encode(1u32.encode()).into()),
+        );
+
+        // Trigger ocw and send the transaction
+        NodeManager::offchain_worker(System::block_number());
+        let tx = pop_tx_from_mempool(pool_state);
+        assert_ok!(tx.call.clone().dispatch(frame_system::RawOrigin::None.into()));
+
+        // The owner should not get any reward because all the nodes were deregistered
+        assert_eq!(Balances::free_balance(&context.owner), initial_owner_balance);
+
+        // The pot balance should stay the same because all the nodes were deregistered
+        assert_eq!(
+            Balances::free_balance(&NodeManager::compute_reward_account_id()),
+            initial_pot_balance
+        );
+
+        // Make sure the failed payment event is emitted
+        System::assert_has_event(
+            Event::ErrorPayingReward {
+                reward_period: reward_period_to_pay,
+                node: context.registered_nodes[num_nodes_to_deregister - 1].clone(),
+                amount: reward_amount / node_count as u128,
+                error: Error::<TestRuntime>::NodeNotRegistered.into(),
+            }
+            .into(),
+        );
+
+        // The payment should succeed
+        assert_eq!(true, <RewardPot<TestRuntime>>::get(reward_period_to_pay).is_none());
+        System::assert_last_event(
+            Event::RewardPayoutCompleted { reward_period_index: reward_period_to_pay }.into(),
+        );
+    });
+}
+
+#[test]
+fn payment_works_some_nodes_deregistered() {
+    let (mut ext, pool_state, offchain_state) = ExtBuilder::build_default()
+        .with_genesis_config()
+        .with_authors()
+        .for_offchain_worker()
+        .as_externality_with_state();
+    ext.execute_with(|| {
+        let node_count = <MaxBatchSize<TestRuntime>>::get();
+        let context = Context::new(node_count as u8);
+        let nodes_to_deregister = vec![context.registered_nodes[0].clone()];
+        let num_nodes_to_deregister = 1u32;
+
+        assert_ok!(NodeManager::deregister_nodes(
+            RuntimeOrigin::signed(context.registrar),
+            context.owner,
+            BoundedVec::truncate_from(nodes_to_deregister),
+            num_nodes_to_deregister,
+        ));
+
+        let reward_period = <RewardPeriod<TestRuntime>>::get();
+        let reward_amount = <RewardAmount<TestRuntime>>::get();
+        let reward_period_length = reward_period.length as u64;
+        let reward_period_to_pay = reward_period.current;
+
+        let initial_pot_balance = Balances::free_balance(&NodeManager::compute_reward_account_id());
+
+        // make sure the pot has the expected amount
+        assert_eq!(initial_pot_balance, reward_amount * 2u128);
+
+        // Complete a reward period
+        roll_forward((reward_period_length - System::block_number()) + 1);
+
+        assert_eq!(
+            <RewardPot<TestRuntime>>::get(reward_period_to_pay).unwrap().total_reward,
+            reward_amount
+        );
+
+        // mock finalised block response
+        mock_get_finalised_block(
+            &mut offchain_state.write(),
+            &Some(hex::encode(1u32.encode()).into()),
+        );
+
+        // Trigger ocw and send the transaction
+        NodeManager::offchain_worker(System::block_number());
+        let tx = pop_tx_from_mempool(pool_state);
+        assert_ok!(tx.call.clone().dispatch(frame_system::RawOrigin::None.into()));
+
+        // Make sure the failed payment event is emitted
+        System::assert_has_event(
+            Event::ErrorPayingReward {
+                reward_period: reward_period_to_pay,
+                node: context.registered_nodes[(num_nodes_to_deregister - 1) as usize].clone(),
+                amount: reward_amount / node_count as u128,
+                error: Error::<TestRuntime>::NodeNotRegistered.into(),
+            }
+            .into(),
+        );
+
+        // The owner should get all rewards minus the nodes that were deregistered
+        let expected_owner_reward_amount =
+            reward_amount / node_count as u128 * (node_count - num_nodes_to_deregister) as u128;
+        assert_eq!(Balances::free_balance(&context.owner), expected_owner_reward_amount);
+
+        // The pot balance should stay the same because all the nodes were deregistered
+        assert_eq!(
+            Balances::free_balance(&NodeManager::compute_reward_account_id()),
+            initial_pot_balance - expected_owner_reward_amount
+        );
+
+        // The payment for the remaing nodes should succeed
+        assert_eq!(true, <RewardPot<TestRuntime>>::get(reward_period_to_pay).is_none());
+        System::assert_last_event(
+            Event::RewardPayoutCompleted { reward_period_index: reward_period_to_pay }.into(),
+        );
+    });
+}
+
+mod fails_when {
+    use super::*;
+
+    #[test]
+    fn sender_is_not_registrar() {
+        let (mut ext, _, _) = ExtBuilder::build_default()
+            .with_genesis_config()
+            .for_offchain_worker()
+            .as_externality_with_state();
+        ext.execute_with(|| {
+            let node_count = <MaxBatchSize<TestRuntime>>::get();
+            let context = Context::new(node_count as u8);
+            let num_nodes_to_deregister = context.registered_nodes.len();
+
+            let bad_origin = RuntimeOrigin::signed(context.owner);
+            assert_noop!(
+                NodeManager::deregister_nodes(
+                    bad_origin,
+                    context.owner,
+                    BoundedVec::truncate_from(context.registered_nodes.clone()),
+                    num_nodes_to_deregister as u32,
+                ),
+                Error::<TestRuntime>::OriginNotRegistrar
+            );
+        });
+    }
+
+    #[test]
+    fn node_is_not_registered() {
+        let (mut ext, _, _) = ExtBuilder::build_default()
+            .with_genesis_config()
+            .for_offchain_worker()
+            .as_externality_with_state();
+        ext.execute_with(|| {
+            let node_count = <MaxBatchSize<TestRuntime>>::get();
+            let context = Context::new(node_count as u8);
+            let num_nodes_to_deregister = 2u32;
+
+            let bad_node = context.owner;
+            assert_noop!(
+                NodeManager::deregister_nodes(
+                    RuntimeOrigin::signed(context.registrar),
+                    context.owner,
+                    BoundedVec::truncate_from(vec![bad_node, context.registered_nodes[0].clone()]),
+                    num_nodes_to_deregister,
+                ),
+                Error::<TestRuntime>::NodeNotOwnedByOwner
+            );
+        });
+    }
+
+    #[test]
+    fn owner_is_not_registered() {
+        let (mut ext, _, _) = ExtBuilder::build_default()
+            .with_genesis_config()
+            .for_offchain_worker()
+            .as_externality_with_state();
+        ext.execute_with(|| {
+            let node_count = <MaxBatchSize<TestRuntime>>::get();
+            let context = Context::new(node_count as u8);
+            let num_nodes_to_deregister = context.registered_nodes.len();
+
+            let bad_owner = context.registrar;
+            assert_noop!(
+                NodeManager::deregister_nodes(
+                    RuntimeOrigin::signed(context.registrar),
+                    bad_owner,
+                    BoundedVec::truncate_from(context.registered_nodes.clone()),
+                    num_nodes_to_deregister as u32,
+                ),
+                Error::<TestRuntime>::NodeNotOwnedByOwner
+            );
+        });
+    }
+
+    #[test]
+    fn number_of_nodes_is_incorrect() {
+        let (mut ext, _, _) = ExtBuilder::build_default()
+            .with_genesis_config()
+            .for_offchain_worker()
+            .as_externality_with_state();
+        ext.execute_with(|| {
+            let node_count = <MaxBatchSize<TestRuntime>>::get();
+            let context = Context::new(node_count as u8);
+
+            let bad_number_to_deregister = 1u32;
+            assert_noop!(
+                NodeManager::deregister_nodes(
+                    RuntimeOrigin::signed(context.registrar),
+                    context.owner,
+                    BoundedVec::truncate_from(context.registered_nodes.clone()),
+                    bad_number_to_deregister,
+                ),
+                Error::<TestRuntime>::InvalidNumberOfNodes
+            );
+        });
+    }
+}

--- a/runtime/src/proxy_config.rs
+++ b/runtime/src/proxy_config.rs
@@ -172,6 +172,13 @@ impl ProvableProxy<RuntimeCall, Signature, AccountId> for AvnProxyConfig {
                 market_id: _,
                 block_number: _,
             }) => return Some(proof.clone()),
+            RuntimeCall::NodeManager(pallet_node_manager::Call::signed_deregister_nodes {
+                proof,
+                owner: _,
+                nodes_to_deregister: _,
+                block_number: _,
+                number_of_nodes_to_deregister: _,
+            }) => return Some(proof.clone()),
             _ => None,
         }
     }


### PR DESCRIPTION
## Proposed changes

This PR implements new functionality to allow the node registrar to deregister nodes. Tests and benchmarking are also included here

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will be born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->


