### PR TITLE
feat: Adds new state migration for owned node counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,7 +631,7 @@ checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "avn-key-subcommand"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "clap 4.5.4",
  "hex",
@@ -1241,7 +1241,7 @@ checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
 
 [[package]]
 name = "common-primitives"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "arbitrary",
  "fixed",
@@ -5027,7 +5027,7 @@ dependencies = [
 
 [[package]]
 name = "node-macros"
-version = "1.14.0"
+version = "1.15.0"
 
 [[package]]
 name = "node-primitives"
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-config"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-node-manager"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "frame-benchmarking",
@@ -5698,7 +5698,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-authorized"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5717,7 +5717,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-court"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "arrayvec 0.7.4",
  "common-primitives",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-eth-asset-registry"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-global-disputes"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5787,7 +5787,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-hybrid-router"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "cfg-if 1.0.0",
  "common-primitives",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-market-commons"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5846,7 +5846,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-neo-swaps"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "cfg-if 1.0.0",
  "common-primitives",
@@ -5891,7 +5891,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-pm-order-book"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "env_logger",
@@ -5916,7 +5916,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-prediction-markets"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "cfg-if 1.0.0",
  "common-primitives",
@@ -5957,7 +5957,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-prediction-markets-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "parity-scale-codec 3.6.9",
  "prediction-market-primitives",
@@ -6648,7 +6648,7 @@ dependencies = [
 
 [[package]]
 name = "prediction-market-primitives"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "arbitrary",
  "common-primitives",
@@ -10467,7 +10467,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tnf-node"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "avn-key-subcommand",
  "cfg-if 0.1.10",
@@ -10530,7 +10530,7 @@ dependencies = [
 
 [[package]]
 name = "tnf-node-runtime"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "common-primitives",
  "frame-benchmarking",
@@ -10608,7 +10608,7 @@ dependencies = [
 
 [[package]]
 name = "tnf-service"
-version = "1.14.0"
+version = "1.15.0"
 dependencies = [
  "anyhow",
  "ethereum-types 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "1.14.0"
+version = "1.15.0"
 authors = ["Aventus systems team"]
 homepage = "https://www.truth-network.io/"
 edition = "2021"

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1368,7 +1368,7 @@ pub type Executive = frame_executive::Executive<
     AllPalletsWithSystem,
     (
         pallet_eth_bridge::migration::EthBridgeMigrations<Runtime>,
-        pallet_node_manager::migration::RewardPeriodInfoUpgrade<Runtime>,
+        pallet_node_manager::migration::OwnedNodesUpgrade<Runtime>,
     ),
 >;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -289,7 +289,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     //   `spec_version`, and `authoring_version` are the same between Wasm and native.
     // This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
     //   the compatible custom types.
-    spec_version: 30,
+    spec_version: 31,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 1,


### PR DESCRIPTION
## Proposed changes

This PR adds state migration to node manager to record a counter of owned nodes per node owner. This will be used by the watchtower pallet to calculate voting weight.

## Type of change/Merge

🚨What type of change is this PR? </br>
_Put an `x` in the boxes that apply_

- [x] Release <!---Mark this option if a new release/version will be born from this PR-->
  - [x] Increase versions <!---If checked, the spec_version will be increased and the impl_version reset to zero-->
  - [ ] Baseline tests passed  <!---If checked, you are guaranteeing the baseline tests were successfully on the most successfull run of the PR-->
  - Release type:
    - [ ] Major release <!---i.ex v1.0.0 => v2.0.0-->
    - [x] Minor release <!---i.ex v1.0.0 => v1.2.0-->
    - [ ] Patch release <!---i.ex v1.0.0 => v1.0.1-->

