### PR TITLE
feat: new pallet setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ pallet-pm-order-book = { path = "pallets/order-book", default-features = false }
 pallet-pm-eth-asset-registry = { path = "pallets/eth-asset-registry", default-features = false }
 pallet-node-manager = { path = "pallets/node-manager", default-features = false }
 pallet-config = { path = "pallets/config", default-features = false }
+pallet-watchtower = { path = "pallets/watchtower", default-features = false }
 
 # Other (client)
 clap = "4.5.4"

--- a/pallets/watchtower/Cargo.toml
+++ b/pallets/watchtower/Cargo.toml
@@ -1,0 +1,72 @@
+[package]
+name = "pallet-watchtower"
+publish = false
+
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+
+
+[dependencies]
+# Third-party
+parity-scale-codec = { workspace = true, features = ["derive", "max-encoded-len"] }
+log = { workspace = true }
+scale-info = { workspace = true, features = ["derive", "serde"]}
+hex = { workspace = true }
+
+# Substrate primitives
+sp-core = { workspace = true}
+sp-io = { workspace = true}
+sp-runtime = { workspace = true}
+sp-std = { workspace = true}
+sp-api = { workspace = true}
+
+frame-benchmarking = { workspace = true, optional = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+
+pallet-avn = { workspace = true }
+sp-avn-common = { workspace = true }
+common-primitives = { workspace = true }
+prediction-market-primitives = { workspace = true }
+sp-application-crypto = { workspace = true }
+
+[dev-dependencies]
+sp-application-crypto = { workspace = true }
+sp-avn-common = { workspace = true, features=["test-utils"] }
+sp-keystore = { workspace = true, features = ["default"]}
+sp-state-machine = { workspace = true }
+pallet-timestamp = { workspace = true }
+prediction-market-primitives = { workspace = true, features=["mock"]}
+parking_lot = {  workspace = true }
+pallet-balances = { workspace = true, features=["insecure_zero_ed", "default"] }
+pallet-node-manager = { workspace = true, features=["default"] }
+test-case = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "parity-scale-codec/std",
+    "log/std",
+    "scale-info/std",
+    "sp-api/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "frame-benchmarking?/std",
+    "frame-support/std",
+    "frame-system/std",
+    "pallet-avn/std",
+    "sp-avn-common/std",
+    "common-primitives/std",
+]
+runtime-benchmarks = [
+    "frame-benchmarking/runtime-benchmarks",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/pallets/watchtower/src/lib.rs
+++ b/pallets/watchtower/src/lib.rs
@@ -1,0 +1,78 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#[cfg(not(feature = "std"))]
+extern crate alloc;
+#[cfg(not(feature = "std"))]
+use alloc::{
+    format,
+    string::{String, ToString},
+    vec,
+};
+
+use frame_support::{
+    dispatch::DispatchResult,
+    pallet_prelude::*,
+    traits::{IsSubType, IsType},
+    weights::WeightMeter,
+};
+use frame_system::{offchain::SendTransactionTypes, pallet_prelude::*};
+use parity_scale_codec::{Decode, Encode};
+use sp_core::{MaxEncodedLen, H256};
+pub use sp_runtime::{
+    traits::{AtLeast32Bit, Dispatchable, ValidateUnsigned},
+    transaction_validity::{
+        InvalidTransaction, TransactionPriority, TransactionSource, TransactionValidity,
+        ValidTransaction,
+    },
+    Perbill, SaturatedConversion,
+};
+use sp_runtime::{
+    traits::{IdentifyAccount, Verify},
+    RuntimeAppPublic, Saturating,
+};
+use sp_std::prelude::*;
+
+pub const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+
+pub use pallet::*;
+#[frame_support::pallet]
+pub mod pallet {
+    use super::*;
+
+    #[pallet::pallet]
+    #[pallet::storage_version(STORAGE_VERSION)]
+    pub struct Pallet<T>(_);
+
+    #[pallet::config]
+    pub trait Config: SendTransactionTypes<Call<Self>> + frame_system::Config {
+        type RuntimeEvent: From<Event<Self>>
+            + IsType<<Self as frame_system::Config>::RuntimeEvent>
+            + Clone
+            + Eq
+            + PartialEq
+            + core::fmt::Debug;
+
+        type RuntimeCall: Parameter
+            + Dispatchable<RuntimeOrigin = <Self as frame_system::Config>::RuntimeOrigin>
+            + IsSubType<Call<Self>>
+            + From<Call<Self>>;
+
+        /// Weight information for extrinsics in this pallet
+        type WeightInfo: WeightInfo;
+    }
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+
+    }
+}


### PR DESCRIPTION
This PR introduces a new Substrate pallet called `pallet-watchtower` to the project. The changes include adding the pallet to the workspace, setting up its dependencies, and scaffolding its initial implementation. This sets the foundation for future development of the watchtower functionality.