### PR TITLE
feat: Adds admin setting to update pallet configs

### DIFF
--- a/pallets/watchtower/src/benchmarking.rs
+++ b/pallets/watchtower/src/benchmarking.rs
@@ -1,0 +1,26 @@
+// Copyright 2025 Truth Network.
+
+#![cfg(feature = "runtime-benchmarks")]
+
+use super::*;
+use frame_benchmarking::{account, benchmarks, impl_benchmark_test_suite};
+use frame_system::{EventRecord, RawOrigin};
+use sp_avn_common::Proof;
+use sp_core::crypto::DEV_PHRASE;
+use sp_runtime::{traits::Hash, SaturatedConversion};
+benchmarks! {
+
+    set_admin_config_voting {
+        let new_period: BlockNumberFor<T> = 36u32.into();
+        let config = AdminConfig::MinVotingPeriod(new_period);
+    }: set_admin_config(RawOrigin::Root, config)
+    verify {
+        assert!(<MinVotingPeriod<T>>::get() == new_period);
+    }
+
+}
+impl_benchmark_test_suite!(
+    Pallet,
+    crate::mock::ExtBuilder::build_default().as_externality(),
+    crate::mock::TestRuntime,
+);

--- a/pallets/watchtower/src/tests/admin.rs
+++ b/pallets/watchtower/src/tests/admin.rs
@@ -1,0 +1,56 @@
+//Copyright 2025 Truth Network.
+
+#![cfg(test)]
+
+use crate::{mock::*, *};
+use frame_support::{assert_noop, assert_ok};
+use frame_system::RawOrigin;
+use sp_runtime::DispatchError;
+
+#[test]
+fn origin_is_checked_none() {
+    let mut ext = ExtBuilder::build_default().as_externality();
+    ext.execute_with(|| {
+        let current_period = MinVotingPeriod::<TestRuntime>::get();
+        let new_period = current_period + 1;
+
+        let config = AdminConfig::MinVotingPeriod(new_period);
+        assert_noop!(
+            Watchtower::set_admin_config(RawOrigin::None.into(), config,),
+            DispatchError::BadOrigin
+        );
+    });
+}
+
+#[test]
+fn origin_is_checked_signed() {
+    let mut ext = ExtBuilder::build_default().as_externality();
+    ext.execute_with(|| {
+        let current_period = MinVotingPeriod::<TestRuntime>::get();
+        let new_period = current_period + 1;
+
+        let config = AdminConfig::MinVotingPeriod(new_period);
+        let bad_signer = TestAccount::new([99u8; 32]).account_id();
+        assert_noop!(
+            Watchtower::set_admin_config(RuntimeOrigin::signed(bad_signer.clone()), config,),
+            DispatchError::BadOrigin
+        );
+    });
+}
+
+mod min_voting_period {
+    use super::*;
+
+    #[test]
+    fn min_voting_period_can_be_set() {
+        let mut ext = ExtBuilder::build_default().as_externality();
+        ext.execute_with(|| {
+            let current_period = MinVotingPeriod::<TestRuntime>::get();
+            let new_period = current_period + 1;
+
+            let config = AdminConfig::MinVotingPeriod(new_period);
+            assert_ok!(Watchtower::set_admin_config(RawOrigin::Root.into(), config,));
+            System::assert_last_event(Event::MinVotingPeriodSet { new_period }.into());
+        });
+    }
+}

--- a/pallets/watchtower/src/types.rs
+++ b/pallets/watchtower/src/types.rs
@@ -71,3 +71,7 @@ impl<T: Config> Proposal<T> {
         base_is_valid && payload_valid
     }
 }
+#[derive(Encode, Decode, TypeInfo, Debug, Clone, PartialEq)]
+pub enum AdminConfig<BlockNumber> {
+    MinVotingPeriod(BlockNumber),
+}


### PR DESCRIPTION
This PR introduces a new admin configuration system to the `Watchtower` pallet, allowing privileged users (root) to update the minimum voting period via an extrinsic. It adds the necessary storage, event, call, and benchmarking/test infrastructure to support this feature.
