### PR TITLE
feat: Implement add proposal flow

### DIFF
--- a/pallets/watchtower/src/benchmarking.rs
+++ b/pallets/watchtower/src/benchmarking.rs
@@ -8,8 +8,55 @@ use frame_system::{EventRecord, RawOrigin};
 use sp_avn_common::Proof;
 use sp_core::crypto::DEV_PHRASE;
 use sp_runtime::{traits::Hash, SaturatedConversion};
-benchmarks! {
 
+fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
+    let events = frame_system::Pallet::<T>::events();
+    let system_event: <T as frame_system::Config>::RuntimeEvent = generic_event.into();
+    // compare to the last event record
+    let EventRecord { event, .. } = &events[events.len().saturating_sub(1 as usize)];
+    assert_eq!(event, &system_event);
+}
+
+fn create_proposal_request<T: Config>(
+    external_ref_id: u32,
+    created_at: u32,
+    is_internal: bool,
+) -> ProposalRequest {
+    let external_ref: T::Hash = T::Hashing::hash_of(&external_ref_id);
+    let source: ProposalSource;
+
+    if is_internal {
+        source = ProposalSource::Internal(ProposalType::Governance);
+    } else {
+        source = ProposalSource::External;
+    };
+
+    ProposalRequest {
+        title: "Dummy Proposal".as_bytes().to_vec(),
+        external_ref: H256::from_slice(&external_ref.as_ref()),
+        threshold: Perbill::from_percent(50),
+        payload: RawPayload::Uri(external_ref_id.encode()),
+        source,
+        decision_rule: DecisionRule::SimpleMajority,
+        created_at,
+        vote_duration: Some(MinVotingPeriod::<T>::get().saturated_into::<u32>() + 1u32),
+    }
+}
+benchmarks! {
+    submit_external_proposal {
+        let signer: T::AccountId = account("signer", 0, 0);
+        let proposal_request = create_proposal_request::<T>(1, 1u32, false);
+        let external_ref = proposal_request.external_ref;
+    }: submit_external_proposal(RawOrigin::Signed(signer), proposal_request)
+    verify {
+        assert!(ExternalRef::<T>::contains_key(external_ref));
+
+        let proposal_id = ExternalRef::<T>::get(external_ref);
+        assert!(ProposalStatus::<T>::get(proposal_id) == ProposalStatusEnum::Active);
+        assert_last_event::<T>(
+            Event::ProposalSubmitted { proposal_id, external_ref, status: ProposalStatusEnum::Active }.into()
+        );
+    }
     set_admin_config_voting {
         let new_period: BlockNumberFor<T> = 36u32.into();
         let config = AdminConfig::MinVotingPeriod(new_period);

--- a/pallets/watchtower/src/default_weights.rs
+++ b/pallets/watchtower/src/default_weights.rs
@@ -37,12 +37,30 @@ use core::marker::PhantomData;
 
 /// Weight functions needed for pallet_watchtower.
 pub trait WeightInfo {
+	fn submit_external_proposal() -> Weight;
 	fn set_admin_config_voting() -> Weight;
 }
 
 /// Weights for pallet_watchtower using the Substrate node and recommended hardware.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:0)
+	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ExternalRef` (r:1 w:1)
+	/// Proof: `Watchtower::ExternalRef` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Proposals` (r:1 w:1)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	fn submit_external_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `4`
+		//  Estimated: `8196`
+		// Minimum execution time: 25_726_000 picoseconds.
+		Weight::from_parts(27_724_000, 8196)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
 	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:1)
 	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn set_admin_config_voting() -> Weight {
@@ -58,6 +76,23 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 
 // For backwards compatibility and tests.
 impl WeightInfo for () {
+	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:0)
+	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ExternalRef` (r:1 w:1)
+	/// Proof: `Watchtower::ExternalRef` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Proposals` (r:1 w:1)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	fn submit_external_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `4`
+		//  Estimated: `8196`
+		// Minimum execution time: 25_726_000 picoseconds.
+		Weight::from_parts(27_724_000, 8196)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
 	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:1)
 	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
 	fn set_admin_config_voting() -> Weight {


### PR DESCRIPTION
This PR adds support for submitting external proposals to the `watchtower` pallet, including a new extrinsic, event, error handling, and benchmarking/weight logic. 
