### PR TITLE
feat: Support signed add proposal

### DIFF
--- a/pallets/watchtower/src/default_weights.rs
+++ b/pallets/watchtower/src/default_weights.rs
@@ -38,6 +38,7 @@ use core::marker::PhantomData;
 /// Weight functions needed for pallet_watchtower.
 pub trait WeightInfo {
 	fn submit_external_proposal() -> Weight;
+	fn signed_submit_external_proposal() -> Weight;
 	fn set_admin_config_voting() -> Weight;
 }
 
@@ -58,6 +59,23 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		//  Estimated: `8196`
 		// Minimum execution time: 25_726_000 picoseconds.
 		Weight::from_parts(27_724_000, 8196)
+			.saturating_add(T::DbWeight::get().reads(3_u64))
+			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:0)
+	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ExternalRef` (r:1 w:1)
+	/// Proof: `Watchtower::ExternalRef` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Proposals` (r:1 w:1)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	fn signed_submit_external_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `4`
+		//  Estimated: `8196`
+		// Minimum execution time: 28_007_000 picoseconds.
+		Weight::from_parts(36_989_000, 8196)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
 	}
@@ -90,6 +108,23 @@ impl WeightInfo for () {
 		//  Estimated: `8196`
 		// Minimum execution time: 25_726_000 picoseconds.
 		Weight::from_parts(27_724_000, 8196)
+			.saturating_add(RocksDbWeight::get().reads(3_u64))
+			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:0)
+	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ExternalRef` (r:1 w:1)
+	/// Proof: `Watchtower::ExternalRef` (`max_values`: None, `max_size`: Some(80), added: 2555, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Proposals` (r:1 w:1)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	fn signed_submit_external_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `4`
+		//  Estimated: `8196`
+		// Minimum execution time: 28_007_000 picoseconds.
+		Weight::from_parts(36_989_000, 8196)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
 	}

--- a/pallets/watchtower/src/proxy.rs
+++ b/pallets/watchtower/src/proxy.rs
@@ -1,0 +1,38 @@
+use crate::*;
+
+const SIGNED_SUBMIT_EXTERNAL_PROPOSAL_CONTEXT: &'static [u8] = b"wt_submit_external_proposal";
+const SIGNED_SUBMIT_VOTE_CONTEXT: &'static [u8] = b"wt_submit_vote";
+
+impl<T: Config> Pallet<T> {
+    // external_ref will ensure signature re-use is not possible but we also add a lifetime (block
+    // number) to be on the safe side.
+    pub fn encode_signed_submit_external_proposal_params(
+        relayer: &T::AccountId,
+        proposal: &ProposalRequest,
+        block_number: &BlockNumberFor<T>,
+    ) -> Vec<u8> {
+        (SIGNED_SUBMIT_EXTERNAL_PROPOSAL_CONTEXT, relayer.clone(), proposal, block_number).encode()
+    }
+
+    pub fn get_encoded_call_param(
+        call: &<T as Config>::RuntimeCall,
+    ) -> Option<(&Proof<T::Signature, T::AccountId>, Vec<u8>)> {
+        let call = match call.is_sub_type() {
+            Some(call) => call,
+            None => return None,
+        };
+
+        match call {
+            Call::signed_submit_external_proposal { ref proof, ref block_number, ref proposal } => {
+                let encoded_data = Self::encode_signed_submit_external_proposal_params(
+                    &proof.relayer,
+                    proposal,
+                    block_number,
+                );
+
+                Some((proof, encoded_data))
+            },
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces support for signed external proposal submissions in the `watchtower` pallet. The changes add a new extrinsic for signed submissions, integrate signature verification logic, extend configuration options, and update weight calculations to reflect the new functionality.
