### PR TITLE
feat: Adds support for voting

### DIFF
--- a/pallets/watchtower/src/benchmarking.rs
+++ b/pallets/watchtower/src/benchmarking.rs
@@ -17,6 +17,43 @@ fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
     assert_eq!(event, &system_event);
 }
 
+fn create_proposal<T: Config>(
+    external_ref_id: u32,
+    created_at: BlockNumberFor<T>,
+    end_at: Option<BlockNumberFor<T>>,
+    is_internal: bool,
+) -> Proposal<T> {
+    let external_ref: T::Hash = T::Hashing::hash_of(&external_ref_id);
+    let inner_payload = BoundedVec::try_from(external_ref_id.encode()).unwrap();
+    let source: ProposalSource;
+    let proposer: Option<T::AccountId>;
+
+    if is_internal {
+        source = ProposalSource::Internal(ProposalType::Governance);
+        proposer = None;
+    } else {
+        source = ProposalSource::External;
+        proposer = Some(account("proposer", 0, 0));
+    };
+
+    Proposal {
+        title: BoundedVec::try_from("Bench proposal".as_bytes().to_vec()).unwrap(),
+        external_ref: H256::from_slice(&external_ref.as_ref()),
+        threshold: Perbill::from_percent(50),
+        payload: Payload::Inline(inner_payload),
+        source,
+        proposer,
+        decision_rule: DecisionRule::SimpleMajority,
+        created_at,
+        vote_duration: if let Some(end) = end_at {
+            end.saturating_sub(created_at).saturated_into::<u32>()
+        } else {
+            MinVotingPeriod::<T>::get().saturated_into::<u32>()
+        },
+        end_at,
+    }
+}
+
 fn create_proposal_request<T: Config>(
     external_ref_id: u32,
     created_at: u32,
@@ -42,6 +79,65 @@ fn create_proposal_request<T: Config>(
         vote_duration: Some(MinVotingPeriod::<T>::get().saturated_into::<u32>() + 1u32),
     }
 }
+
+fn set_active_proposal<T: Config>(proposal_id: H256, created_at: u32, length: u32) -> Proposal<T> {
+    let created_at: BlockNumberFor<T> = created_at.into();
+    let active_proposal =
+        create_proposal::<T>(1, created_at, Some(created_at + length.into()), true);
+    Proposals::<T>::insert(proposal_id, &active_proposal);
+    ActiveInternalProposal::<T>::put(proposal_id);
+    ProposalStatus::<T>::insert(proposal_id, ProposalStatusEnum::Active);
+    active_proposal
+}
+
+fn queue_proposal<T: Config>(proposal_id: H256, created_at: u32) -> Proposal<T> {
+    let created_at: BlockNumberFor<T> = created_at.into();
+    let queued_proposal = create_proposal::<T>(2, created_at, None, true);
+    Proposals::<T>::insert(proposal_id, &queued_proposal);
+    Pallet::<T>::enqueue(proposal_id).unwrap();
+    ProposalStatus::<T>::insert(proposal_id, ProposalStatusEnum::Queued);
+    queued_proposal
+}
+
+fn get_proof<T: Config>(
+    relayer: &T::AccountId,
+    signer: &T::AccountId,
+    signature: &[u8],
+) -> Proof<T::Signature, T::AccountId> {
+    return Proof {
+        signer: signer.clone(),
+        relayer: relayer.clone(),
+        signature: sp_core::sr25519::Signature::from_slice(signature).unwrap().into(),
+    }
+}
+
+fn get_voter<T: Config>() -> (T::SignerId, T::AccountId) {
+    let mnemonic: &str = DEV_PHRASE;
+    let key_pair = T::SignerId::generate_pair(Some(mnemonic.as_bytes().to_vec()));
+    let account_bytes = into_bytes::<T>(&key_pair);
+    let account_id = T::AccountId::decode(&mut &account_bytes.encode()[..]).unwrap();
+    return (key_pair, account_id);
+}
+
+fn into_bytes<T: Config>(account: &T::SignerId) -> [u8; 32] {
+    let bytes = account.encode();
+    let mut vector: [u8; 32] = Default::default();
+    vector.copy_from_slice(&bytes[0..32]);
+    return vector;
+}
+
+fn setup_votes<T: Config>(proposal_id: ProposalId, vote_count: u32) {
+    Votes::<T>::mutate(proposal_id, |v| {
+        v.in_favors = vote_count;
+        v.againsts = vote_count;
+    });
+
+    for i in 0..vote_count {
+        let voter: T::AccountId = account("voter", i, 0);
+        Voters::<T>::insert(proposal_id, &voter, true);
+    }
+}
+
 benchmarks! {
     submit_external_proposal {
         let signer: T::AccountId = account("signer", 0, 0);
@@ -55,6 +151,124 @@ benchmarks! {
         assert!(ProposalStatus::<T>::get(proposal_id) == ProposalStatusEnum::Active);
         assert_last_event::<T>(
             Event::ProposalSubmitted { proposal_id, external_ref, status: ProposalStatusEnum::Active }.into()
+        );
+    }
+
+    signed_submit_external_proposal {
+        let (signer_key, signer) = get_voter::<T>();
+        let proposal_request = create_proposal_request::<T>(1, 1u32, false);
+        let external_ref = proposal_request.external_ref;
+        let relayer: T::AccountId = account("relayer", 11, 11);
+        let now = frame_system::Pallet::<T>::block_number();
+        let signed_payload = Pallet::<T>::encode_signed_submit_external_proposal_params(
+            &relayer.clone(),
+            &proposal_request,
+            &now,
+        );
+
+        let signature = signer_key.sign(&signed_payload).unwrap().encode();
+        let proof = get_proof::<T>(&relayer.clone(), &signer, &signature);
+    }: submit_external_proposal(RawOrigin::Signed(signer), proposal_request)
+    verify {
+        assert!(ExternalRef::<T>::contains_key(external_ref));
+
+        let proposal_id = ExternalRef::<T>::get(external_ref);
+        assert!(ProposalStatus::<T>::get(proposal_id) == ProposalStatusEnum::Active);
+        assert_last_event::<T>(
+            Event::ProposalSubmitted { proposal_id, external_ref, status: ProposalStatusEnum::Active }.into()
+        );
+    }
+
+    vote {
+        let in_favor = true;
+        let (_, voter) = get_voter::<T>();
+
+        let proposal_id = H256::repeat_byte(3);
+        let _ = set_active_proposal::<T>(proposal_id, 1u32, 50u32);
+    }: vote(RawOrigin::Signed(voter.clone()), proposal_id, in_favor)
+    verify {
+        assert!(Votes::<T>::contains_key(proposal_id));
+        assert!(Voters::<T>::contains_key(proposal_id, &voter));
+        assert_last_event::<T>(
+            Event::VoteSubmitted { proposal_id, voter, in_favor, vote_weight: 1 }.into()
+        );
+    }
+
+    vote_end_proposal {
+        let in_favor = true;
+        let (_, voter) = get_voter::<T>();
+
+        let proposal_id = H256::repeat_byte(3);
+        let proposal = set_active_proposal::<T>(proposal_id, 1u32, 50u32);
+        // Add some votes to be above the threshold
+        setup_votes::<T>(proposal_id, 9u32);
+    }: vote(RawOrigin::Signed(voter.clone()), proposal_id, in_favor)
+    verify {
+        assert!(Votes::<T>::contains_key(proposal_id));
+        assert!(Voters::<T>::contains_key(proposal_id, &voter));
+        assert_last_event::<T>(
+            Event::VotingEnded {
+                proposal_id,
+                external_ref: proposal.external_ref,
+                consensus_result: ProposalStatusEnum::Resolved { passed: true }}.into()
+        );
+    }
+
+    signed_vote {
+        let (voter_key, voter) = get_voter::<T>();
+        let in_favor = true;
+        let relayer: T::AccountId = account("relayer", 11, 11);
+        let now = frame_system::Pallet::<T>::block_number();
+        let proposal_id = H256::repeat_byte(3);
+        let _ = set_active_proposal::<T>(proposal_id, 1u32, 50u32);
+
+        let signed_payload = Pallet::<T>::encode_signed_submit_vote_params(
+            &relayer.clone(),
+            &proposal_id,
+            &in_favor,
+            &now,
+        );
+
+        let signature = voter_key.sign(&signed_payload).unwrap().encode();
+        let proof = get_proof::<T>(&relayer.clone(), &voter, &signature);
+    }: signed_vote(RawOrigin::Signed(voter.clone()), proposal_id, in_favor, now, proof)
+    verify {
+        assert!(Votes::<T>::contains_key(proposal_id));
+        assert!(Voters::<T>::contains_key(proposal_id, &voter));
+        assert_last_event::<T>(
+            Event::VoteSubmitted { proposal_id, voter, in_favor, vote_weight: 1 }.into()
+        );
+    }
+
+    signed_vote_end_proposal {
+        let (voter_key, voter) = get_voter::<T>();
+        let in_favor = true;
+        let relayer: T::AccountId = account("relayer", 11, 11);
+        let now = frame_system::Pallet::<T>::block_number();
+        let proposal_id = H256::repeat_byte(3);
+        let proposal = set_active_proposal::<T>(proposal_id, 1u32, 50u32);
+
+        let signed_payload = Pallet::<T>::encode_signed_submit_vote_params(
+            &relayer.clone(),
+            &proposal_id,
+            &in_favor,
+            &now,
+        );
+
+        let signature = voter_key.sign(&signed_payload).unwrap().encode();
+        let proof = get_proof::<T>(&relayer.clone(), &voter, &signature);
+
+        // Add some votes to be above the threshold
+        setup_votes::<T>(proposal_id, 9u32);
+    }: signed_vote(RawOrigin::Signed(voter.clone()), proposal_id, in_favor, now, proof)
+    verify {
+        assert!(Votes::<T>::contains_key(proposal_id));
+        assert!(Voters::<T>::contains_key(proposal_id, &voter));
+        assert_last_event::<T>(
+            Event::VotingEnded {
+                proposal_id,
+                external_ref: proposal.external_ref,
+                consensus_result: ProposalStatusEnum::Resolved { passed: true }}.into()
         );
     }
     set_admin_config_voting {

--- a/pallets/watchtower/src/default_weights.rs
+++ b/pallets/watchtower/src/default_weights.rs
@@ -39,6 +39,10 @@ use core::marker::PhantomData;
 pub trait WeightInfo {
 	fn submit_external_proposal() -> Weight;
 	fn signed_submit_external_proposal() -> Weight;
+	fn vote() -> Weight;
+	fn vote_end_proposal() -> Weight;
+	fn signed_vote() -> Weight;
+	fn signed_vote_end_proposal() -> Weight;
 	fn set_admin_config_voting() -> Weight;
 }
 
@@ -78,6 +82,90 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 		Weight::from_parts(36_989_000, 8196)
 			.saturating_add(T::DbWeight::get().reads(3_u64))
 			.saturating_add(T::DbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:0)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	fn vote() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `266`
+		//  Estimated: `8196`
+		// Minimum execution time: 29_508_000 picoseconds.
+		Weight::from_parts(36_665_000, 8196)
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Tail` (r:1 w:0)
+	/// Proof: `Watchtower::Tail` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Head` (r:1 w:0)
+	/// Proof: `Watchtower::Head` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalsToRemove` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalsToRemove` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ActiveInternalProposal` (r:0 w:1)
+	/// Proof: `Watchtower::ActiveInternalProposal` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	fn vote_end_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `646`
+		//  Estimated: `8196`
+		// Minimum execution time: 52_275_000 picoseconds.
+		Weight::from_parts(61_505_000, 8196)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:0)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	fn signed_vote() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `266`
+		//  Estimated: `8196`
+		// Minimum execution time: 114_240_000 picoseconds.
+		Weight::from_parts(146_835_000, 8196)
+			.saturating_add(T::DbWeight::get().reads(4_u64))
+			.saturating_add(T::DbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Tail` (r:1 w:0)
+	/// Proof: `Watchtower::Tail` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Head` (r:1 w:0)
+	/// Proof: `Watchtower::Head` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalsToRemove` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalsToRemove` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ActiveInternalProposal` (r:0 w:1)
+	/// Proof: `Watchtower::ActiveInternalProposal` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	fn signed_vote_end_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `646`
+		//  Estimated: `8196`
+		// Minimum execution time: 144_130_000 picoseconds.
+		Weight::from_parts(177_289_000, 8196)
+			.saturating_add(T::DbWeight::get().reads(6_u64))
+			.saturating_add(T::DbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:1)
 	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)
@@ -127,6 +215,90 @@ impl WeightInfo for () {
 		Weight::from_parts(36_989_000, 8196)
 			.saturating_add(RocksDbWeight::get().reads(3_u64))
 			.saturating_add(RocksDbWeight::get().writes(3_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:0)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	fn vote() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `266`
+		//  Estimated: `8196`
+		// Minimum execution time: 29_508_000 picoseconds.
+		Weight::from_parts(36_665_000, 8196)
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Tail` (r:1 w:0)
+	/// Proof: `Watchtower::Tail` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Head` (r:1 w:0)
+	/// Proof: `Watchtower::Head` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalsToRemove` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalsToRemove` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ActiveInternalProposal` (r:0 w:1)
+	/// Proof: `Watchtower::ActiveInternalProposal` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	fn vote_end_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `646`
+		//  Estimated: `8196`
+		// Minimum execution time: 52_275_000 picoseconds.
+		Weight::from_parts(61_505_000, 8196)
+			.saturating_add(RocksDbWeight::get().reads(6_u64))
+			.saturating_add(RocksDbWeight::get().writes(5_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:0)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	fn signed_vote() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `266`
+		//  Estimated: `8196`
+		// Minimum execution time: 114_240_000 picoseconds.
+		Weight::from_parts(146_835_000, 8196)
+			.saturating_add(RocksDbWeight::get().reads(4_u64))
+			.saturating_add(RocksDbWeight::get().writes(2_u64))
+	}
+	/// Storage: `Watchtower::Proposals` (r:1 w:0)
+	/// Proof: `Watchtower::Proposals` (`max_values`: None, `max_size`: Some(4731), added: 7206, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalStatus` (r:1 w:1)
+	/// Proof: `Watchtower::ProposalStatus` (`max_values`: None, `max_size`: Some(50), added: 2525, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Voters` (r:1 w:1)
+	/// Proof: `Watchtower::Voters` (`max_values`: None, `max_size`: Some(97), added: 2572, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Votes` (r:1 w:1)
+	/// Proof: `Watchtower::Votes` (`max_values`: None, `max_size`: Some(56), added: 2531, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Tail` (r:1 w:0)
+	/// Proof: `Watchtower::Tail` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::Head` (r:1 w:0)
+	/// Proof: `Watchtower::Head` (`max_values`: Some(1), `max_size`: Some(8), added: 503, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ProposalsToRemove` (r:0 w:1)
+	/// Proof: `Watchtower::ProposalsToRemove` (`max_values`: None, `max_size`: Some(48), added: 2523, mode: `MaxEncodedLen`)
+	/// Storage: `Watchtower::ActiveInternalProposal` (r:0 w:1)
+	/// Proof: `Watchtower::ActiveInternalProposal` (`max_values`: Some(1), `max_size`: Some(32), added: 527, mode: `MaxEncodedLen`)
+	fn signed_vote_end_proposal() -> Weight {
+		// Proof Size summary in bytes:
+		//  Measured:  `646`
+		//  Estimated: `8196`
+		// Minimum execution time: 144_130_000 picoseconds.
+		Weight::from_parts(177_289_000, 8196)
+			.saturating_add(RocksDbWeight::get().reads(6_u64))
+			.saturating_add(RocksDbWeight::get().writes(5_u64))
 	}
 	/// Storage: `Watchtower::MinVotingPeriod` (r:1 w:1)
 	/// Proof: `Watchtower::MinVotingPeriod` (`max_values`: Some(1), `max_size`: Some(4), added: 499, mode: `MaxEncodedLen`)

--- a/pallets/watchtower/src/types.rs
+++ b/pallets/watchtower/src/types.rs
@@ -117,6 +117,13 @@ impl<T: Config> Proposal<T> {
         base_is_valid && payload_valid
     }
 }
+
+#[derive(Encode, Decode, RuntimeDebug, Clone, PartialEq, Eq, TypeInfo, MaxEncodedLen, Default)]
+pub struct Vote {
+    pub in_favors: u32,
+    pub againsts: u32,
+}
+
 #[derive(Encode, Decode, TypeInfo, Debug, Clone, PartialEq)]
 pub enum AdminConfig<BlockNumber> {
     MinVotingPeriod(BlockNumber),

--- a/pallets/watchtower/src/vote.rs
+++ b/pallets/watchtower/src/vote.rs
@@ -1,0 +1,129 @@
+use crate::*;
+
+impl<T: Config> Pallet<T> {
+    pub fn threshold_achieved(proposal_id: ProposalId, threshold: Perbill) -> Option<bool> {
+        let vote = Votes::<T>::get(proposal_id);
+        let total_voters = T::Watchtowers::get_authorized_watchtowers_count();
+        if total_voters == 0 {
+            return None;
+        }
+
+        let min_votes = threshold.mul_ceil(total_voters);
+        if vote.in_favors >= min_votes {
+            Some(true)
+        } else if vote.againsts >= min_votes {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_proposal_status(result: bool) -> ProposalStatusEnum {
+        if result {
+            ProposalStatusEnum::Resolved { passed: true }
+        } else {
+            ProposalStatusEnum::Resolved { passed: false }
+        }
+    }
+
+    pub fn get_vote_result_on_expiry(
+        proposal_id: ProposalId,
+        proposal: &Proposal<T>,
+    ) -> ProposalStatusEnum {
+        match proposal.source {
+            ProposalSource::Internal(_) => ProposalStatusEnum::Expired,
+            ProposalSource::External => {
+                let votes = Votes::<T>::get(proposal_id);
+                if proposal.decision_rule == DecisionRule::SimpleMajority &&
+                    votes.in_favors > votes.againsts
+                {
+                    ProposalStatusEnum::Resolved { passed: true }
+                } else {
+                    ProposalStatusEnum::Resolved { passed: false }
+                }
+            },
+        }
+    }
+
+    pub fn finalise_expired_voting(
+        proposal_id: ProposalId,
+        proposal: &Proposal<T>,
+    ) -> DispatchResult {
+        let consensus_result = Self::get_vote_result_on_expiry(proposal_id, proposal);
+        Self::finalise_voting(proposal_id, proposal, consensus_result)
+    }
+
+    pub fn finalise_voting(
+        proposal_id: ProposalId,
+        proposal: &Proposal<T>,
+        consensus_result: ProposalStatusEnum,
+    ) -> DispatchResult {
+        ProposalStatus::<T>::insert(proposal_id, consensus_result.clone());
+        // If this was an internal proposal, activate the next one in the queue
+        if let ProposalSource::Internal(_) = proposal.source {
+            ActiveInternalProposal::<T>::kill();
+            if let Ok(next_proposal_id) = Self::dequeue() {
+                ActiveInternalProposal::<T>::put(next_proposal_id);
+                ProposalStatus::<T>::insert(next_proposal_id, ProposalStatusEnum::Active);
+                // Try to mutate and fetch the proposal in one storage access
+                let updated_proposal = Proposals::<T>::try_mutate(next_proposal_id, |p_opt| {
+                    let p = p_opt.as_mut().ok_or(Error::<T>::ProposalNotFound)?;
+                    p.end_at =
+                        Some(frame_system::Pallet::<T>::block_number() + p.vote_duration.into());
+                    Ok::<_, Error<T>>(p.clone())
+                })?;
+
+                T::WatchtowerHooks::on_proposal_submitted(next_proposal_id, updated_proposal)?;
+            }
+        }
+
+        T::WatchtowerHooks::on_voting_completed(
+            proposal_id,
+            &proposal.external_ref,
+            &consensus_result,
+        );
+
+        ProposalsToRemove::<T>::insert(proposal_id, ());
+
+        Self::deposit_event(Event::VotingEnded {
+            proposal_id,
+            external_ref: proposal.external_ref,
+            consensus_result,
+        });
+
+        Ok(())
+    }
+
+    pub fn get_finalised_consensus_result(
+        proposal_id: ProposalId,
+        proposal: &Proposal<T>,
+        current_block: BlockNumberFor<T>,
+    ) -> Option<ProposalStatusEnum> {
+        if let Some(result) = Self::threshold_achieved(proposal_id, proposal.threshold) {
+            Some(Self::get_proposal_status(result))
+        } else if Self::proposal_expired(current_block, proposal) {
+            Some(Self::get_vote_result_on_expiry(proposal_id, proposal))
+        } else {
+            None
+        }
+    }
+
+    pub fn proposal_expired(current_block: BlockNumberFor<T>, proposal: &Proposal<T>) -> bool {
+        current_block >= proposal.end_at.unwrap_or(0u32.into())
+    }
+
+    pub fn active_proposal_expiry_status(
+        now: BlockNumberFor<T>,
+    ) -> Option<(ProposalId, Proposal<T>, bool)> {
+        let Some(proposal_id) = ActiveInternalProposal::<T>::get() else {
+            return None;
+        };
+
+        let Some(active_proposal) = <Proposals<T>>::get(proposal_id) else {
+            return None;
+        };
+
+        let expired = Self::proposal_expired(now, &active_proposal);
+        Some((proposal_id, active_proposal, expired))
+    }
+}


### PR DESCRIPTION
This PR introduces comprehensive voting functionality to the `watchtower` pallet, including new storage items, events, benchmarking, and weight calculations for voting-related extrinsics. The changes enable proposals to be voted on, track votes and voters, and emit relevant events when votes are cast or consensus is reached.